### PR TITLE
CI: Run tests in Cygwin for Cygwin CI

### DIFF
--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -33,7 +33,7 @@ jobs:
           packages: >-
             python3${{ matrix.python-minor }}
             python3${{ matrix.python-minor }}-pip
-            cmake make ninja gcc-core
+            cmake make ninja gcc-core gcc-g++
 
       - name: Install nox
         shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -44,7 +44,7 @@ jobs:
             python3${{ matrix.python-minor }}
             python3${{ matrix.python-minor }}-pip
             cmake make ninja gcc-core gcc-g++ git
-            gnupg gnupg2 meson
+            gnupg gnupg2 meson pkg-config
 
       - name: Tell Cygwin git about this repository
         # This addresses the "fatal: detected dubious ownership in

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -56,7 +56,6 @@ jobs:
           TMP: "/tmp"
           TEMP: "/tmp"
         run: |
-          cd "${GITHUB_WORKSPACE}"
           nox -s test-3.${{ matrix.python-minor }}
 
       - name: Send coverage report

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -42,7 +42,7 @@ jobs:
             python3${{ matrix.python-minor }}
             python3${{ matrix.python-minor }}-pip
             cmake make ninja gcc-core gcc-g++ git
-            gnupg gnupg2
+            gnupg gnupg2 meson
 
       - name: Install nox
         shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: windows-latest
     env:
       FORCE_COLOR: true
+      SHELLOPTS: igncr
+      CHERE_INVOKING: true
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +45,15 @@ jobs:
             python3${{ matrix.python-minor }}-pip
             cmake make ninja gcc-core gcc-g++ git
             gnupg gnupg2 meson
+
+      - name: Tell Cygwin git about this repository
+        # This addresses the "fatal: detected dubious ownership in
+        # repository" and "fatal: not in a git directory" errors
+        # encountered when trying to run Cygwin git in a directory not
+        # owned by the current user. This happens when the tests run
+        # Cygwin git in a directory outside the Cygwin filesystem.
+        run: git config --global --add safe.directory '*'
+        shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -leo pipefail -o igncr {0}
 
       - name: Install nox
         shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - uses: actions/cache@v3
+        with:
+          path: 'C:\cygwin'
+          key: ${{ runner.os }}-cygwin-python-3${{ matrix.python-minor }}-${{ hashfiles('pyproject.toml') }}
+
       - name: Setup Cygwin
         uses: cygwin/cygwin-install-action@v2
         with:

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -33,7 +33,7 @@ jobs:
           packages: >-
             python3${{ matrix.python-minor }}
             python3${{ matrix.python-minor }}-pip
-            cmake make ninja
+            cmake make ninja gcc-core
 
       - name: Install nox
         shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -33,7 +33,7 @@ jobs:
           packages: >-
             python3${{ matrix.python-minor }}
             python3${{ matrix.python-minor }}-pip
-            cmake make ninja gcc-core gcc-g++
+            cmake make ninja gcc-core gcc-g++ git
 
       - name: Install nox
         shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -24,6 +24,9 @@ jobs:
           - '9'
 
     steps:
+      - name: Tell git to use proper newlines
+        run: git config --global core.autocrlf input
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -39,6 +42,8 @@ jobs:
         shell: bash.exe -eo pipefail -o igncr "{0}"
         env:
           PATH: "/bin:/usr/bin:/usr/local/bin:/usr/lib/lapack"
+          TMP: "/tmp"
+          TEMP: "/tmp"
         run: |
             /usr/bin/python -m pip install nox
             nox --version
@@ -47,7 +52,12 @@ jobs:
         shell: bash.exe -eo pipefail -o igncr "{0}"
         env:
           PATH: "/bin:/usr/bin:/usr/local/bin:/usr/lib/lapack"
-        run: nox -s test-3.${{ matrix.python-minor }}
+          CHERE_INVOKING: 1
+          TMP: "/tmp"
+          TEMP: "/tmp"
+        run: |
+          cd "${GITHUB_WORKSPACE}"
+          nox -s test-3.${{ matrix.python-minor }}
 
       - name: Send coverage report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -42,6 +42,7 @@ jobs:
             python3${{ matrix.python-minor }}
             python3${{ matrix.python-minor }}-pip
             cmake make ninja gcc-core gcc-g++ git
+            gnupg gnupg2
 
       - name: Install nox
         shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -20,35 +20,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python:
-          - '3.10'
+        python-minor:
+          - '9'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up target Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-
       - name: Setup Cygwin
         uses: cygwin/cygwin-install-action@v2
+        with:
+          packages: >-
+            python3${{ matrix.python-minor }}
+            python3${{ matrix.python-minor }}-pip
 
       - name: Install nox
+        shell: bash.exe -eo pipefail -o igncr "{0}"
         run: |
-            python -m pip install nox
+            /usr/bin/python -m pip install nox
             nox --version
 
       - name: Run tests
-        run: nox -s test-${{ matrix.python }}
+        shell: bash.exe -eo pipefail -o igncr "{0}"
+        run: nox -s test-3.${{ matrix.python-minor }}
 
       - name: Send coverage report
         uses: codecov/codecov-action@v1
         if: ${{ always() }}
         env:
-          PYTHON: cygwin-${{ matrix.python }}
+          PYTHON: cygwin-3.${{ matrix.python-minor }}
         with:
           flags: tests
           env_vars: PYTHON
-          name: cygwin-${{ matrix.python }}
+          name: cygwin-3.${{ matrix.python-minor }}

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -65,6 +65,16 @@ jobs:
             /usr/bin/python -m pip install nox
             nox --version
 
+      - name: Download setuptools/pip wheels for ensurepip
+        shell: bash.exe -eo pipefail -o igncr "{0}"
+        env:
+          PATH: "/bin:/usr/bin:/usr/local/bin:/usr/lib/lapack"
+          TMP: "/tmp"
+          TEMP: "/tmp"
+        run: |
+          mkdir -p /usr/share/python-wheels
+          /usr/bin/python -m pip wheel --wheel-dir /usr/share/python-wheels setuptools pip wheel
+
       - name: Run tests
         shell: bash.exe -eo pipefail -o igncr "{0}"
         env:

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -33,6 +33,7 @@ jobs:
           packages: >-
             python3${{ matrix.python-minor }}
             python3${{ matrix.python-minor }}-pip
+            cmake make ninja
 
       - name: Install nox
         shell: bash.exe -eo pipefail -o igncr "{0}"

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -36,12 +36,16 @@ jobs:
 
       - name: Install nox
         shell: bash.exe -eo pipefail -o igncr "{0}"
+        env:
+          PATH: "/bin:/usr/bin:/usr/local/bin:/usr/lib/lapack"
         run: |
             /usr/bin/python -m pip install nox
             nox --version
 
       - name: Run tests
         shell: bash.exe -eo pipefail -o igncr "{0}"
+        env:
+          PATH: "/bin:/usr/bin:/usr/local/bin:/usr/lib/lapack"
         run: nox -s test-3.${{ matrix.python-minor }}
 
       - name: Send coverage report

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -99,6 +99,7 @@ _STYLES = _init_colors()  # holds the color values, should be _COLORS or _NO_COL
 
 
 _LINUX_NATIVE_MODULE_REGEX = re.compile(r'^(?P<name>.+)\.(?P<tag>.+)\.so$')
+_CYGWIN_NATIVE_MODULE_REGEX = re.compile(r'^(?P<name>.+)\.(?P<tag>.+)\.dll$')
 _WINDOWS_NATIVE_MODULE_REGEX = re.compile(r'^(?P<name>.+)\.(?P<tag>.+)\.pyd$')
 _STABLE_ABI_TAG_REGEX = re.compile(r'^abi(?P<abi_number>[0-9]+)$')
 
@@ -292,7 +293,7 @@ class _WheelBuilder():
         # preventive and check its value to make sure it matches our expectations
         try:
             extension = sysconfig.get_config_vars().get('SHLIB_SUFFIX', '.so')
-            if extension != '.so':
+            if extension not in ('.so', '.dll'):
                 raise NotImplementedError(
                     f"We don't currently support the {extension} extension. "
                     'Please report this to https://github.com/FFY00/mesonpy/issues '
@@ -305,7 +306,10 @@ class _WheelBuilder():
                 'Please report this to https://github.com/FFY00/mesonpy/issues '
                 'and include the output of `python -m sysconfig`.'
             )
-        match = _LINUX_NATIVE_MODULE_REGEX.match(filename)
+        if sys.platform == 'cygwin':
+            match = _CYGWIN_NATIVE_MODULE_REGEX.match(filename)
+        else:
+            match = _LINUX_NATIVE_MODULE_REGEX.match(filename)
         if not match:  # this file does not appear to be a native module
             return None
         tag = match.group('tag')

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,7 @@
 
 import os
 import os.path
+import platform
 
 import nox
 
@@ -45,6 +46,10 @@ def test(session):
     # optional github actions integration
     if os.environ.get('GITHUB_ACTIONS') == 'true':
         session.install('pytest-github-actions-annotate-failures')
+
+    # https://github.com/gitpython-developers/GitPython/pull/1455
+    if platform.system().startswith('CYGWIN'):
+        session.install('git+https://github.com/gitpython-developers/GitPython.git')
 
     session.run(
         'pytest',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
   'Cython',
   'pyproject-metadata>=0.6.1',
   'wheel',
+  'importlib_metadata; python_version < "3.8"',
 ]
 docs = [
   'furo>=2021.08.31',

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -102,7 +102,7 @@ def test_scipy_like(wheel_scipy_like):
             'mypkg/submod/__init__.py',
             'mypkg/submod/unknown_filetype.npq',
         }
-    if os.name == 'nt':
+    if os.name == 'nt' or sys.platform == 'cygwin':
         # Currently Meson is installing `.dll.a` (import libraries) next to
         # `.pyd` extension modules. Those are very small, so it's not a major
         # issue - just sloppy. For now, ensure we don't fail on those
@@ -154,6 +154,8 @@ def test_purelib_and_platlib(wheel_purelib_and_platlib):
     }
     if platform.system() == 'Windows':
         expecting.add('plat{}'.format(EXT_SUFFIX.replace('pyd', 'dll.a')))
+    elif sys.platform == 'cygwin':
+        expecting.add('plat{}'.format(EXT_SUFFIX.replace('dll', 'dll.a')))
 
     assert wheel_contents(artifact) == expecting
 
@@ -216,6 +218,7 @@ def test_executable_bit(wheel_executable_bit):
     executable_files = {
         'executable_bit-1.0.0.data/purelib/executable_module.py',
         'executable_bit-1.0.0.data/scripts/example',
+        'executable_bit-1.0.0.data/scripts/example.exe',
         'executable_bit-1.0.0.data/scripts/example-script',
         'executable_bit-1.0.0.data/data/bin/example-script',
     }

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -28,7 +28,8 @@ EXT_SUFFIX = sysconfig.get_config_var('EXT_SUFFIX')
 INTERPRETER_VERSION = f'{sys.version_info[0]}{sys.version_info[1]}'
 
 
-if platform.python_implementation() == 'CPython':
+python_implementation = platform.python_implementation()
+if python_implementation == 'CPython' or python_implementation.startswith('CYGWIN'):
     INTERPRETER_TAG = f'cp{INTERPRETER_VERSION}'
     PYTHON_TAG = INTERPRETER_TAG
     # Py_UNICODE_SIZE has been a runtime option since Python 3.3,
@@ -40,11 +41,11 @@ if platform.python_implementation() == 'CPython':
         pymalloc = sysconfig.get_config_var('WITH_PYMALLOC')
         if pymalloc or pymalloc is None:  # none is the default value, which is enable
             INTERPRETER_TAG += 'm'
-elif platform.python_implementation() == 'PyPy':
+elif python_implementation == 'PyPy':
     INTERPRETER_TAG = sysconfig.get_config_var('SOABI').replace('-', '_')
     PYTHON_TAG = f'pp{INTERPRETER_VERSION}'
 else:
-    raise NotImplementedError(f'Unknown implementation: {platform.python_implementation()}')
+    raise NotImplementedError(f'Unknown implementation: {python_implementation}')
 
 PLATFORM_TAG = sysconfig.get_platform().replace('-', '_').replace('.', '_')
 
@@ -52,7 +53,7 @@ if platform.system() == 'Linux':
     SHARED_LIB_EXT = 'so'
 elif platform.system() == 'Darwin':
     SHARED_LIB_EXT = 'dylib'
-elif platform.system() == 'Windows':
+elif platform.system() == 'Windows' or platform.system().startswith('CYGWIN'):
     SHARED_LIB_EXT = 'pyd'
 else:
     raise NotImplementedError(f'Unknown system: {platform.system()}')


### PR DESCRIPTION
The current version installs the Cygwin base packages (but not any python versions), then runs the rest of the steps using the previously-installed Windows-native python.  This should run the tests in a Cygwin python.