### PR TITLE
ENH: add support for editable wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .mesonpy-native-file.ini
+.mesonpy/
 docs/_build
 *.pyc
 .cache/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,56 @@ frontend, like ``builddir``, to specify the build directory to use/re-use. You
 can find more information about them in the `build options page`_.
 
 
+Editable installs
+-----------------
+
+Editable installs allow you to install the project in such a way where you can
+edit the project source and have those changes be reflected in the installed
+module, without having to explicitly rebuild and reinstall.
+
+The way it works on ``meson-python`` specifically, is that when you import a
+module of the project, it will be rebuilt on the fly. This means that project
+imports will take more time than usual.
+
+You can use pip to install the project in editable mode.
+
+
+.. code-block::
+
+   python -m pip install -e .
+
+
+It might be helpful to see the output of the Meson_ commands. This is offered
+as a **provisional** feature, meaning it is subject to change.
+
+If you want to temporarily enable the output, you can set the
+``MESONPY_EDITABLE_VERBOSE`` environment variable to a non-empty value. If this
+environment variable is present during import, the Meson_ commands and their
+output will be printed.
+
+
+.. code-block::
+
+   MESONPY_EDITABLE_VERBOSE=1 python my_script.py
+
+
+
+This behavior can also be enabled by default by passing the ``editable-verbose``
+config setting when installing the project.
+
+
+.. code-block::
+
+   python -m pip install -e . --config-settings editable-verbose=true
+
+
+This way, you won't need to always set ``MESONPY_EDITABLE_VERBOSE`` environment
+variable, the Meson_ commands and their output will always be printed.
+
+The ``MESONPY_EDITABLE_VERBOSE`` won't have any effect during the project
+install step.
+
+
 How does it work?
 =================
 

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ py.install_sources(
   'mesonpy/_compat.py',
   'mesonpy/_editable.py',
   'mesonpy/_elf.py',
+  'mesonpy/_introspection.py',
   'mesonpy/_tags.py',
   'mesonpy/_util.py',
   'mesonpy/_wheelfile.py',

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ endif
 py.install_sources(
   'mesonpy/__init__.py',
   'mesonpy/_compat.py',
+  'mesonpy/_editable.py',
   'mesonpy/_elf.py',
   'mesonpy/_tags.py',
   'mesonpy/_util.py',

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -49,6 +49,7 @@ else:
 
 import mesonpy._compat
 import mesonpy._elf
+import mesonpy._introspection
 import mesonpy._tags
 import mesonpy._util
 import mesonpy._wheelfile
@@ -146,56 +147,6 @@ def _as_python_declaration(value: Any) -> str:
     elif isinstance(value, Iterable):
         return '[' + ', '.join(map(_as_python_declaration, value)) + ']'
     raise NotImplementedError(f'Unsupported type: {type(value)}')
-
-
-@functools.lru_cache()
-def _debian_python() -> bool:
-    """Check if we are running on Debian-patched Python."""
-    if sys.version_info >= (3, 10):
-        return 'deb_system' in sysconfig.get_scheme_names()
-    try:
-        import distutils
-        try:
-            import distutils.command.install
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError('Unable to import distutils, please install python3-distutils')
-        return 'deb_system' in distutils.command.install.INSTALL_SCHEMES
-    except ModuleNotFoundError:
-        return False
-
-
-@functools.lru_cache()
-def _debian_distutils_paths() -> Mapping[str, str]:
-    # https://ffy00.github.io/blog/02-python-debian-and-the-install-locations/
-    assert sys.version_info < (3, 12) and _debian_python()
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning)
-        import distutils.dist
-
-    distribution = distutils.dist.Distribution()
-    install_cmd = distribution.get_command_obj('install')
-    install_cmd.install_layout = 'deb'  # type: ignore[union-attr]
-    install_cmd.finalize_options()  # type: ignore[union-attr]
-
-    return {
-        'data': install_cmd.install_data,  # type: ignore[union-attr]
-        'platlib': install_cmd.install_platlib,  # type: ignore[union-attr]
-        'purelib': install_cmd.install_purelib,  # type: ignore[union-attr]
-        'scripts': install_cmd.install_scripts,  # type: ignore[union-attr]
-    }
-
-
-@functools.lru_cache()
-def _sysconfig_paths() -> Mapping[str, str]:
-    sys_vars = sysconfig.get_config_vars().copy()
-    sys_vars['base'] = sys_vars['platbase'] = sys.base_prefix
-    if _debian_python():
-        if sys.version_info >= (3, 10):
-            return sysconfig.get_paths('deb_system', vars=sys_vars)
-        else:
-            return _debian_distutils_paths()
-    return sysconfig.get_paths(vars=sys_vars)
 
 
 class Error(RuntimeError):
@@ -461,9 +412,9 @@ class _WheelBuilder():
         origin file and the Meson destination path.
         """
         warnings.warn('Using heuristics to map files to wheel, this may result in incorrect locations')
-        sys_paths = _sysconfig_paths()
+        sys_paths = mesonpy._introspection.SYSCONFIG_PATHS
         # Try to map to Debian dist-packages
-        if _debian_python():
+        if mesonpy._introspection.DEBIAN_PYTHON:
             search_path = origin
             while search_path != search_path.parent:
                 search_path = search_path.parent
@@ -634,7 +585,7 @@ class _WheelBuilder():
         rebuild_commands = self._project.build_commands(install_path)
 
         import_paths = set()
-        for name, raw_path in _sysconfig_paths().items():
+        for name, raw_path in mesonpy._introspection.SYSCONFIG_PATHS.items():
             if name not in ('purelib', 'platlib'):
                 continue
             path = pathlib.Path(raw_path)
@@ -833,7 +784,7 @@ class Project():
         We will try to reconfigure the build directory if possible to avoid
         expensive rebuilds.
         """
-        sys_paths = _sysconfig_paths()
+        sys_paths = mesonpy._introspection.SYSCONFIG_PATHS
         setup_args = [
             f'--prefix={sys.base_prefix}',
             os.fspath(self._source_dir),

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -49,18 +49,13 @@ import mesonpy._util
 import mesonpy._wheelfile
 
 from mesonpy._compat import (
-    Collection, Iterator, Literal, Mapping, ParamSpec, Path, typing_get_args
+    Collection, Iterator, Literal, Mapping, ParamSpec, Path, cached_property,
+    typing_get_args
 )
 
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import pyproject_metadata  # noqa: F401
-
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    cached_property = lambda x: property(functools.lru_cache(maxsize=None)(x))  # noqa: E731
 
 
 __version__ = '0.13.0.dev0'

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -301,6 +301,8 @@ class _WheelBuilder():
     @property
     def _debian_python(self) -> bool:
         """Check if we are running on Debian-patched Python."""
+        if sys.version_info >= (3, 10):
+            return 'deb_system' in sysconfig.get_scheme_names()
         try:
             import distutils
             try:

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -194,10 +194,14 @@ class _WheelBuilder():
         return bool(self._wheel_files['platlib'])
 
     @property
+    def normalized_name(self) -> str:
+        return self._project.name.replace('-', '_')
+
+    @property
     def basename(self) -> str:
         """Normalized wheel name and version (eg. meson_python-1.0.0)."""
         return '{distribution}-{version}'.format(
-            distribution=self._project.name.replace('-', '_'),
+            distribution=self.normalized_name,
             version=self._project.version,
         )
 
@@ -541,6 +545,9 @@ class _WheelBuilder():
                         self._install_path(whl, counter, origin, destination)
 
         return wheel_file
+
+    def build_editable(self, directory: Path) -> pathlib.Path:
+        self._build()
 
 
 MesonArgsKeys = Literal['dist', 'setup', 'compile', 'install']

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -1105,11 +1105,9 @@ class Project():
 
     def wheel(self, directory: Path) -> pathlib.Path:
         """Generates a wheel (binary distribution) in the specified directory."""
-        wheel = self._wheel_builder.build(self._build_dir)
-
-        final_wheel = pathlib.Path(directory, wheel.name)
-        shutil.move(os.fspath(wheel), final_wheel)
-        return final_wheel
+        file = self._wheel_builder.build(directory)
+        assert isinstance(file, pathlib.Path)
+        return file
 
     def editable(self, directory: Path) -> pathlib.Path:
         file = self._wheel_builder.build_editable(directory)

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -604,6 +604,8 @@ class _WheelBuilder():
             hook_module_name = f'_mesonpy_hook_{self.normalized_name.replace(".", "_")}'
             hook_install_code = textwrap.dedent(f'''
                 MesonpyFinder.install(
+                    project_name={_as_python_declaration(self._project.name)},
+                    hook_name={_as_python_declaration(hook_module_name)},
                     project_path={_as_python_declaration(self._source_dir)},
                     build_path={_as_python_declaration(self._build_dir)},
                     import_paths={_as_python_declaration(import_paths)},

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -519,7 +519,7 @@ class _WheelBuilder():
         Some files might need to be fixed up to set the RPATH to the internal
         library directory on Linux wheels for eg.
         """
-        location = os.fspath(destination).replace(os.path.sep, '/')
+        location = destination.as_posix()
         counter.update(location)
 
         # fix file

--- a/mesonpy/_compat.py
+++ b/mesonpy/_compat.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2021 Quansight, LLC
 # SPDX-FileCopyrightText: 2021 Filipe Laíns <lains@riseup.net>
 
+import functools
 import os
 import pathlib
 import sys
@@ -30,6 +31,12 @@ else:
     from typing_extensions import get_args as typing_get_args
 
 
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    cached_property = lambda x: property(functools.lru_cache(maxsize=None)(x))  # noqa: E731
+
+
 Path = Union[str, os.PathLike]
 
 
@@ -43,6 +50,7 @@ def is_relative_to(path: pathlib.Path, other: Union[pathlib.Path, str]) -> bool:
 
 
 __all__ = [
+    'cached_property',
     'is_relative_to',
     'typing_get_args',
     'Collection',

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -1,0 +1,90 @@
+import functools
+import importlib.abc
+import subprocess
+import sys
+
+from types import ModuleType
+from typing import List, Optional, Union
+
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Sequence
+else:
+    from typing import Sequence
+
+
+# This file should be standalone!
+# It is copied during the editable hook installation.
+
+
+class MesonpyFinder(importlib.abc.MetaPathFinder):
+    """Custom loader that whose purpose is to detect when the import system is
+    trying to load our modules, and trigger a rebuild. After triggering a
+    rebuild, we return None in find_spec, letting the normal finders pick up the
+    modules.
+    """
+
+    def __init__(
+        self,
+        project_path: str,
+        build_path: str,
+        import_paths: List[str],
+        top_level_modules: List[str],
+        rebuild_commands: List[List[str]],
+    ) -> None:
+        self._project_path = project_path
+        self._build_path = build_path
+        self._import_paths = import_paths
+        self._top_level_modules = top_level_modules
+        self._rebuild_commands = rebuild_commands
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}({self._project_path})'
+
+    @functools.lru_cache(maxsize=1)
+    def rebuild(self) -> None:
+        for command in self._rebuild_commands:
+            subprocess.check_output(command, cwd=self._build_path)
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Optional[Sequence[Union[str, bytes]]],
+        target: Optional[ModuleType] = None,
+    ) -> None:
+        # if it's one of our modules, trigger a rebuild
+        if fullname.split('.', maxsplit=1)[0] in self._top_level_modules:
+            self.rebuild()
+            # prepend the project path to sys.path, so that the normal finder
+            # can find our modules
+            # we prepend so that our path comes before the current path (if
+            # the interpreter is run with -m), see gh-239
+            if sys.path[:len(self._import_paths)] != self._import_paths:
+                for path in self._import_paths:
+                    if path in sys.path:
+                        sys.path.remove(path)
+                sys.path = self._import_paths + sys.path
+        # return none (meaning we "didn't find" the module) and let the normal
+        # finders find/import it
+        return None
+
+    @classmethod
+    def install(
+        cls,
+        project_path: str,
+        build_path: str,
+        import_paths: List[str],
+        top_level_modules: List[str],
+        rebuild_commands: List[List[str]],
+    ) -> None:
+        finder = cls(project_path, build_path, import_paths, top_level_modules, rebuild_commands)
+        if finder not in sys.meta_path:
+            # prepend our finder to sys.meta_path, so that it is queried before
+            # the normal finders, and can trigger a project rebuild
+            sys.meta_path.insert(0, finder)
+            # we add the project path to sys.path later, so that we can prepend
+            # after the current directory is prepended (when -m is used)
+            # see gh-239
+
+
+# generated hook install below

--- a/mesonpy/_introspection.py
+++ b/mesonpy/_introspection.py
@@ -50,7 +50,7 @@ def sysconfig_paths() -> Mapping[str, str]:
     sys_vars = sysconfig.get_config_vars().copy()
     sys_vars['base'] = sys_vars['platbase'] = sys.base_prefix
     if DEBIAN_PYTHON:
-        if sys.version_info >= (3, 10):
+        if sys.version_info >= (3, 10, 3):
             return sysconfig.get_paths('deb_system', vars=sys_vars)
         else:
             return debian_distutils_paths()

--- a/mesonpy/_introspection.py
+++ b/mesonpy/_introspection.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+import sysconfig
+import warnings
+
+from mesonpy._compat import Mapping
+
+
+def debian_python() -> bool:
+    """Check if we are running on Debian-patched Python."""
+    if sys.version_info >= (3, 10):
+        return 'deb_system' in sysconfig.get_scheme_names()
+    try:
+        import distutils
+        try:
+            import distutils.command.install
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('Unable to import distutils, please install python3-distutils')
+        return 'deb_system' in distutils.command.install.INSTALL_SCHEMES
+    except ModuleNotFoundError:
+        return False
+
+
+DEBIAN_PYTHON = debian_python()
+
+
+def debian_distutils_paths() -> Mapping[str, str]:
+    # https://ffy00.github.io/blog/02-python-debian-and-the-install-locations/
+    assert sys.version_info < (3, 12) and DEBIAN_PYTHON
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
+        import distutils.dist
+
+    distribution = distutils.dist.Distribution()
+    install_cmd = distribution.get_command_obj('install')
+    install_cmd.install_layout = 'deb'  # type: ignore[union-attr]
+    install_cmd.finalize_options()  # type: ignore[union-attr]
+
+    return {
+        'data': install_cmd.install_data,  # type: ignore[union-attr]
+        'platlib': install_cmd.install_platlib,  # type: ignore[union-attr]
+        'purelib': install_cmd.install_purelib,  # type: ignore[union-attr]
+        'scripts': install_cmd.install_scripts,  # type: ignore[union-attr]
+    }
+
+
+def sysconfig_paths() -> Mapping[str, str]:
+    sys_vars = sysconfig.get_config_vars().copy()
+    sys_vars['base'] = sys_vars['platbase'] = sys.base_prefix
+    if DEBIAN_PYTHON:
+        if sys.version_info >= (3, 10):
+            return sysconfig.get_paths('deb_system', vars=sys_vars)
+        else:
+            return debian_distutils_paths()
+    return sysconfig.get_paths(vars=sys_vars)
+
+
+SYSCONFIG_PATHS = sysconfig_paths()
+
+
+__all__ = [
+    'DEBIAN_PYTHON',
+    'SYSCONFIG_PATHS',
+]

--- a/mesonpy/_tags.py
+++ b/mesonpy/_tags.py
@@ -29,7 +29,7 @@ def get_interpreter_tag() -> str:
 
 
 def _get_config_var(name: str, default: Union[str, int, None] = None) -> Union[str, int, None]:
-    value = sysconfig.get_config_var(name)
+    value: Union[str, int, None] = sysconfig.get_config_var(name)
     if value is None:
         return default
     return value

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def docs(session):
 
 @nox.session(python='3.7')
 def mypy(session):
-    session.install('mypy==0.981')
+    session.install('mypy==0.991')
 
     session.run('mypy', '-p', 'mesonpy')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,11 @@ multi_line_output = 5
 known_first_party = 'mesonpy'
 
 
+[tool.coverage.run]
+disable_warnings = [
+  'couldnt-parse',
+]
+
 [tool.coverage.html]
 show_contexts = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
   'pyproject-metadata>=0.6.1',
   'tomli>=1.0.0; python_version<"3.11"',
   'typing-extensions>=3.7.4; python_version<"3.10"',
+  'importlib_resources>=5.0.0; python_version<"3.10"',
 ]
 
 [project]
@@ -29,6 +30,7 @@ dependencies = [
   'pyproject-metadata>=0.6.1', # not a hard dependency, only needed for projects that use PEP 621 metadata
   'tomli>=1.0.0; python_version<"3.11"',
   'typing-extensions>=3.7.4; python_version<"3.10"',
+  'importlib_resources>=5.0.0; python_version<"3.10"',
 ]
 
 dynamic = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,13 +97,9 @@ class VEnv(EnvBuilder):
 
 
 @pytest.fixture()
-def venv():
-    path = pathlib.Path(tempfile.mkdtemp(prefix='mesonpy-test-venv-'))
-    venv = VEnv(path)
-    try:
-        yield venv
-    finally:
-        shutil.rmtree(path)
+def venv(tmp_path_factory):
+    path = pathlib.Path(tmp_path_factory.mktemp('mesonpy-test-venv'))
+    return VEnv(path)
 
 
 def generate_package_fixture(package):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,12 +126,21 @@ def generate_wheel_fixture(package):
     return fixture
 
 
+def generate_editable_fixture(package):
+    @pytest.fixture(scope='session')
+    def fixture(tmp_path_session):
+        with chdir(package_dir / package), in_git_repo_context():
+            return tmp_path_session / mesonpy.build_editable(tmp_path_session)
+    return fixture
+
+
 # inject {package,sdist,wheel}_* fixtures (https://github.com/pytest-dev/pytest/issues/2424)
 for package in os.listdir(package_dir):
     normalized = package.replace('-', '_')
     globals()[f'package_{normalized}'] = generate_package_fixture(package)
     globals()[f'sdist_{normalized}'] = generate_sdist_fixture(package)
     globals()[f'wheel_{normalized}'] = generate_wheel_fixture(package)
+    globals()[f'editable_{normalized}'] = generate_editable_fixture(package)
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,12 @@ class VEnv(EnvBuilder):
         self.executable = context.env_exe
         return context
 
+    def python(self, *args: str):
+        return subprocess.check_output([self.executable, *args]).decode()
+
+    def pip(self, *args: str):
+        return self.python('-m', 'pip', *args)
+
 
 @pytest.fixture()
 def venv():

--- a/tests/packages/imports-itself-during-build/meson.build
+++ b/tests/packages/imports-itself-during-build/meson.build
@@ -1,0 +1,15 @@
+project(
+    'imports-itself-during-build', 'c',
+    version: '1.0.0',
+)
+
+py_mod = import('python')
+py = py_mod.find_installation()
+
+py.install_sources('pure.py')
+py.extension_module(
+    'plat', 'plat.c',
+    install: true,
+)
+
+run_command(py, '-c', 'import pure')

--- a/tests/packages/imports-itself-during-build/plat.c
+++ b/tests/packages/imports-itself-during-build/plat.c
@@ -1,0 +1,24 @@
+#include <Python.h>
+
+static PyObject* foo(PyObject* self)
+{
+    return PyUnicode_FromString("bar");
+}
+
+static PyMethodDef methods[] = {
+    {"foo", (PyCFunction)foo, METH_NOARGS, NULL},
+    {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "plat",
+    NULL,
+    -1,
+    methods,
+};
+
+PyMODINIT_FUNC PyInit_plat(void)
+{
+    return PyModule_Create(&module);
+}

--- a/tests/packages/imports-itself-during-build/pure.py
+++ b/tests/packages/imports-itself-during-build/pure.py
@@ -1,0 +1,2 @@
+def foo():
+    return 'bar'

--- a/tests/packages/imports-itself-during-build/pyproject.toml
+++ b/tests/packages/imports-itself-during-build/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']

--- a/tests/packages/module-types/meson.build
+++ b/tests/packages/module-types/meson.build
@@ -1,0 +1,21 @@
+project(
+    'module-types', 'c',
+    version: '1.0.0',
+)
+
+py_mod = import('python')
+py = py_mod.find_installation()
+
+py.install_sources('file.py')
+py.install_sources(
+    'package' / '__init__.py',
+    subdir: 'package',
+)
+py.install_sources(
+    'namespace' / 'data.py',
+    subdir: 'namespace',
+)
+py.extension_module(
+    'native', 'native.c',
+    install: true,
+)

--- a/tests/packages/module-types/native.c
+++ b/tests/packages/module-types/native.c
@@ -1,0 +1,24 @@
+#include <Python.h>
+
+static PyObject* foo(PyObject* self)
+{
+    return PyUnicode_FromString("bar");
+}
+
+static PyMethodDef methods[] = {
+    {"foo", (PyCFunction)foo, METH_NOARGS, NULL},
+    {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "native",
+    NULL,
+    -1,
+    methods,
+};
+
+PyMODINIT_FUNC PyInit_native(void)
+{
+    return PyModule_Create(&module);
+}

--- a/tests/packages/module-types/pyproject.toml
+++ b/tests/packages/module-types/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -95,13 +95,3 @@ def test_user_args(package_user_args, mocker, tmp_path_session):
 def test_unknown_user_args(package, tmp_path_session):
     with pytest.raises(mesonpy.ConfigError):
         mesonpy.Project(package_dir / f'unknown-user-args-{package}', tmp_path_session)
-
-
-def test_top_level_modules(package_module_types):
-    with mesonpy.Project.with_temp_working_dir() as project:
-        assert set(project.top_level_modules) == {
-            'file',
-            'package',
-            'namespace',
-            'native',
-        }

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -95,3 +95,13 @@ def test_user_args(package_user_args, mocker, tmp_path_session):
 def test_unknown_user_args(package, tmp_path_session):
     with pytest.raises(mesonpy.ConfigError):
         mesonpy.Project(package_dir / f'unknown-user-args-{package}', tmp_path_session)
+
+
+def test_top_level_modules(package_module_types):
+    with mesonpy.Project.with_temp_working_dir() as project:
+        assert set(project.top_level_modules) == {
+            'file',
+            'package',
+            'namespace',
+            'native',
+        }

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -146,13 +146,8 @@ def test_configure_data(wheel_configure_data):
 
 @pytest.mark.skipif(platform.system() != 'Linux', reason='Unsupported on this platform for now')
 def test_local_lib(venv, wheel_link_against_local_lib):
-    subprocess.run(
-        [venv.executable, '-m', 'pip', 'install', wheel_link_against_local_lib],
-        check=True)
-    output = subprocess.run(
-        [venv.executable, '-c', 'import example; print(example.example_sum(1, 2))'],
-        stdout=subprocess.PIPE,
-        check=True).stdout
+    venv.pip('install', wheel_link_against_local_lib)
+    output = venv.python('-c', 'import example; print(example.example_sum(1, 2))')
     assert int(output) == 3
 
 

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -222,6 +222,16 @@ def test_entrypoints(wheel_full_metadata):
         ''').strip()
 
 
+def test_top_level_modules(package_module_types):
+    with mesonpy.Project.with_temp_working_dir() as project:
+        assert set(project._wheel_builder.top_level_modules) == {
+            'file',
+            'package',
+            'namespace',
+            'native',
+        }
+
+
 def test_editable(
     package_imports_itself_during_build,
     editable_imports_itself_during_build,

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -220,3 +220,22 @@ def test_entrypoints(wheel_full_metadata):
             [gui_scripts]
             example-gui = example:gui
         ''').strip()
+
+
+def test_editable(
+    package_imports_itself_during_build,
+    editable_imports_itself_during_build,
+    venv,
+):
+    venv.pip('install', os.fspath(editable_imports_itself_during_build))
+
+    assert venv.python('-c', 'import plat; print(plat.foo())').strip() == 'bar'
+
+    plat = package_imports_itself_during_build / 'plat.c'
+    plat_text = plat.read_text()
+    try:
+        plat.write_text(plat_text.replace('bar', 'something else'))
+
+        assert venv.python('-c', 'import plat; print(plat.foo())').strip() == 'something else'
+    finally:
+        plat.write_text(plat_text)


### PR DESCRIPTION
~~This is just an initial approach, that is known to not work on all
use-cases. It simply uses .pth files to inject search locations for the
default import finder, for this reason generated files that should be
installed inside modules will not be available.~~

Signed-off-by: Filipe Laíns <lains@riseup.net>