### PR TITLE
CI: set Codecov to "informational" to avoid spurious failures

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,9 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This follows up on the discussion at the bottom of gh-165. The yaml content is the same as Meson uses.
For the docs, see https://docs.codecov.com/docs/commit-status#informational

[ci skip]