### PR TITLE
ENH: use tomllib on Python 3.11+

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -35,7 +35,11 @@ from typing import (
     Union
 )
 
-import tomli
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
 
 import mesonpy._compat
 import mesonpy._elf
@@ -636,7 +640,7 @@ class Project():
         self._meson_native_file = self._source_dir / '.mesonpy-native-file.ini'
 
         # load config -- PEP 621 support is optional
-        self._config = tomli.loads(self._source_dir.joinpath('pyproject.toml').read_text())
+        self._config = tomllib.loads(self._source_dir.joinpath('pyproject.toml').read_text())
         self._pep621 = 'project' in self._config
         if self.pep621:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
   'meson>=0.63.3',
   'ninja',
   'pyproject-metadata>=0.5.0',
-  'tomli>=1.0.0',
+  'tomli>=1.0.0; python_version<"3.11"',
   'typing-extensions>=3.7.4; python_version<"3.8"',
 ]
 
@@ -29,7 +29,7 @@ dependencies = [
   'meson>=0.63.3',
   'ninja',
   'pyproject-metadata>=0.5.0', # not a hard dependency, only needed for projects that use PEP 621 metadata
-  'tomli>=1.0.0',
+  'tomli>=1.0.0; python_version<"3.11"',
   'typing-extensions>=3.7.4; python_version<"3.8"',
 ]
 


### PR DESCRIPTION
Use tomllib if available.
