### PR TITLE
BUG: add generated files to sdist

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -943,7 +943,7 @@ class Project():
                     # MESON_DIST_ROOT could have a different base name
                     # than the actual sdist basename, so we need to rename here
                     file = meson_dist.extractfile(member.name)
-                    member.name = str(pathlib.Path(dist_name, *member_parts[1:]))
+                    member.name = str(pathlib.Path(dist_name, *member_parts[1:]).as_posix())
                     tar.addfile(member, file)
                     continue
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -935,6 +935,9 @@ class Project():
                 path = self._source_dir.joinpath(*member_parts[1:])
 
                 if not path.is_file():
+                    # Could be a generated file, we still need to copy in that case
+                    if member.isfile():
+                        tar.addfile(member, meson_dist.extractfile(member.name))
                     continue
 
                 info = tarfile.TarInfo(member.name)
@@ -943,6 +946,7 @@ class Project():
                 info.mode = int(oct(file_stat.st_mode)[-3:], 8)
 
                 # rewrite the path if necessary, to match the sdist distribution name
+                #print("File is:", path)
                 if dist_name != meson_dist_name:
                     info.name = pathlib.Path(
                         dist_name,

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -934,6 +934,14 @@ class Project():
                     continue
                 path = self._source_dir.joinpath(*member_parts[1:])
 
+                if not path.exists() and member.isfile():
+                    # File doesn't exists on the source diractory but exists on
+                    # the Meson dist, so it is generated file, which we need to
+                    # include.
+                    # See https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonadd_dist_script
+                    tar.addfile(member, meson_dist.extractfile(member.name))
+                    continue
+
                 if not path.is_file():
                     # Could be a generated file, we still need to copy in that case
                     if member.isfile():

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -935,7 +935,7 @@ class Project():
                 path = self._source_dir.joinpath(*member_parts[1:])
 
                 if not path.exists() and member.isfile():
-                    # File doesn't exists on the source diractory but exists on
+                    # File doesn't exists on the source directory but exists on
                     # the Meson dist, so it is generated file, which we need to
                     # include.
                     # See https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonadd_dist_script

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -945,7 +945,11 @@ class Project():
                 if not path.is_file():
                     # Could be a generated file, we still need to copy in that case
                     if member.isfile():
-                        tar.addfile(member, meson_dist.extractfile(member.name))
+                        # MESON_DIST_ROOT could have a different base name
+                        # than the actual sdist basename, so we need to rename here
+                        file = meson_dist.extractfile(member.name)
+                        member.name = str(pathlib.Path(dist_name, *member_parts[1:]))
+                        tar.addfile(member, file)
                     continue
 
                 info = tarfile.TarInfo(member.name)
@@ -954,7 +958,6 @@ class Project():
                 info.mode = int(oct(file_stat.st_mode)[-3:], 8)
 
                 # rewrite the path if necessary, to match the sdist distribution name
-                #print("File is:", path)
                 if dist_name != meson_dist_name:
                     info.name = pathlib.Path(
                         dist_name,

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -939,17 +939,15 @@ class Project():
                     # the Meson dist, so it is generated file, which we need to
                     # include.
                     # See https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonadd_dist_script
-                    tar.addfile(member, meson_dist.extractfile(member.name))
+
+                    # MESON_DIST_ROOT could have a different base name
+                    # than the actual sdist basename, so we need to rename here
+                    file = meson_dist.extractfile(member.name)
+                    member.name = str(pathlib.Path(dist_name, *member_parts[1:]))
+                    tar.addfile(member, file)
                     continue
 
                 if not path.is_file():
-                    # Could be a generated file, we still need to copy in that case
-                    if member.isfile():
-                        # MESON_DIST_ROOT could have a different base name
-                        # than the actual sdist basename, so we need to rename here
-                        file = meson_dist.extractfile(member.name)
-                        member.name = str(pathlib.Path(dist_name, *member_parts[1:]))
-                        tar.addfile(member, file)
                     continue
 
                 info = tarfile.TarInfo(member.name)

--- a/tests/packages/generated-files/example-script.py
+++ b/tests/packages/generated-files/example-script.py
@@ -1,0 +1,3 @@
+#!python
+
+print('hello!')

--- a/tests/packages/generated-files/example.c
+++ b/tests/packages/generated-files/example.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main() {
+	printf("hello!");
+}

--- a/tests/packages/generated-files/executable_module.py
+++ b/tests/packages/generated-files/executable_module.py
@@ -1,0 +1,6 @@
+def foo():
+    return 'bar'
+
+
+if __name__ == '__main__':
+    print('foo?', foo())

--- a/tests/packages/generated-files/generate_version.py
+++ b/tests/packages/generated-files/generate_version.py
@@ -1,0 +1,33 @@
+import os
+import argparse
+
+def write_version_info(path):
+    # A real project would call something to generate this
+    dummy_version = "1.0.0"
+    dummy_hash = "013j2fiejqea"
+    if os.environ.get("MESON_DIST_ROOT"):
+        path = os.path.join(os.environ.get("MESON_DIST_ROOT"), path)
+    with open(path, "w") as file:
+        file.write(f'__version__="{dummy_version}"\n')
+        file.write(
+            f'__git_version__="{dummy_hash}"\n'
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-o", "--outfile", type=str, help="Path to write version info to"
+    )
+    args = parser.parse_args()
+
+    if not args.outfile.endswith(".py"):
+        raise ValueError(
+            f"Output file must be a Python file. "
+            f"Got: {args.outfile} as filename instead"
+        )
+
+    write_version_info(args.outfile)
+
+
+main()

--- a/tests/packages/generated-files/generate_version.py
+++ b/tests/packages/generated-files/generate_version.py
@@ -1,13 +1,14 @@
-import os
 import argparse
+import os
+
 
 def write_version_info(path):
     # A real project would call something to generate this
-    dummy_version = "1.0.0"
-    dummy_hash = "013j2fiejqea"
-    if os.environ.get("MESON_DIST_ROOT"):
-        path = os.path.join(os.environ.get("MESON_DIST_ROOT"), path)
-    with open(path, "w") as file:
+    dummy_version = '1.0.0'
+    dummy_hash = '013j2fiejqea'
+    if os.environ.get('MESON_DIST_ROOT'):
+        path = os.path.join(os.environ.get('MESON_DIST_ROOT'), path)
+    with open(path, 'w') as file:
         file.write(f'__version__="{dummy_version}"\n')
         file.write(
             f'__git_version__="{dummy_hash}"\n'
@@ -17,14 +18,14 @@ def write_version_info(path):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-o", "--outfile", type=str, help="Path to write version info to"
+        '-o', '--outfile', type=str, help='Path to write version info to'
     )
     args = parser.parse_args()
 
-    if not args.outfile.endswith(".py"):
+    if not args.outfile.endswith('.py'):
         raise ValueError(
-            f"Output file must be a Python file. "
-            f"Got: {args.outfile} as filename instead"
+            f'Output file must be a Python file. '
+            f'Got: {args.outfile} as filename instead'
         )
 
     write_version_info(args.outfile)

--- a/tests/packages/generated-files/meson.build
+++ b/tests/packages/generated-files/meson.build
@@ -1,0 +1,39 @@
+project(
+    'executable-bit', 'c',
+    version: '1.0.0',
+)
+
+py_mod = import('python')
+fs = import('fs')
+py = py_mod.find_installation()
+
+executable(
+    'example', 'example.c',
+    install: true,
+)
+
+install_data(
+    'example-script.py',
+    rename: 'example-script',
+    install_dir: get_option('bindir'),
+)
+
+py.install_sources('executable_module.py')
+
+version_gen = files('generate_version.py')
+
+if fs.exists('_version_meson.py')
+    py.install_sources('_version_meson.py')
+else
+    custom_target('write_version_file',
+        output: '_version_meson.py',
+        command: [
+            py, version_gen, '-o', '@OUTPUT@'
+        ],
+        build_by_default: true,
+        build_always_stale: true,
+        install: true,
+        install_dir: py.get_install_dir(pure: false)
+    )
+    meson.add_dist_script(py, version_gen, '-o', '_version_meson.py')
+endif

--- a/tests/packages/generated-files/pyproject.toml
+++ b/tests/packages/generated-files/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -104,6 +104,7 @@ def test_executable_bit(sdist_executable_bit):
             continue
         assert has_execbit(mode) == expected[name], f'Wrong mode for {name}: {mode}'
 
+
 def test_generated_files(sdist_generated_files):
     sdist = tarfile.open(sdist_generated_files, 'r:gz')
     expected = {

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -103,3 +103,18 @@ def test_executable_bit(sdist_executable_bit):
             # this ourselves)
             continue
         assert has_execbit(mode) == expected[name], f'Wrong mode for {name}: {mode}'
+
+def test_generated_files(sdist_generated_files):
+    sdist = tarfile.open(sdist_generated_files, 'r:gz')
+    expected = {
+        'executable_bit-1.0.0/PKG-INFO',
+        'executable_bit-1.0.0/example-script.py',
+        'executable_bit-1.0.0/example.c',
+        'executable_bit-1.0.0/executable_module.py',
+        'executable_bit-1.0.0/meson.build',
+        'executable_bit-1.0.0/pyproject.toml',
+        'executable_bit-1.0.0/_version_meson.py',
+        'executable_bit-1.0.0/generate_version.py',
+    }
+    assert set(tar.name for tar in sdist.getmembers()) == expected
+

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -117,4 +117,3 @@ def test_generated_files(sdist_generated_files):
         'executable_bit-1.0.0/generate_version.py',
     }
     assert set(tar.name for tar in sdist.getmembers()) == expected
-


### PR DESCRIPTION
Generated files were not being added to the sdist.
This is useful for pandas, since we run a versioneer script to generate the sdist.

I think scipy avoids this, since they don't add generate a version file for their sdist?

I'll add a test, sometime in the future, but I'm a little busy now, so feel free to push to this branch in the meantime.