### PR TITLE
TST: allow custom test selection

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -52,5 +52,5 @@ def test(session):
         '--cov', '--cov-config', 'setup.cfg',
         f'--cov-report=html:{htmlcov_output}',
         f'--cov-report=xml:{xmlcov_output}',
-        'tests/', *session.posargs
+        *session.posargs
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,5 @@ show_contexts = true
 
 [tool:pytest]
 norecursedirs = tests/packages/*
+testpaths =
+    tests


### PR DESCRIPTION
Currently, you cannot select a specific testfile/test to run when running with nox. This allows specific tests to be selected and is backward compatible.

```bash
nox -s test-3.10 -- tests/test_pep517.py::test_get_requires_for_build_wheel
```

Didn't work before this PR.
