### PR TITLE
BUG: Fix breakage when used with Tox

### DIFF
--- a/mesonpy/_util.py
+++ b/mesonpy/_util.py
@@ -47,7 +47,7 @@ def create_targz(path: Path) -> Iterator[Tuple[tarfile.TarFile, Optional[int]]]:
     mtime = int(source_date_epoch) if source_date_epoch else None
 
     file = typing.cast(IO[bytes], gzip.GzipFile(
-        os.path.join(path, path),
+        path,
         mode='wb',
         mtime=mtime,
     ))


### PR DESCRIPTION
Remove an unnecessary `os.path.join()` call that broke when the output directory was a relative path.

This mistake was hidden in most cases because joining two absolute paths
together with os.path.join() results in the first path being dropped.

Fixes meson-python used with Tox.