### PR TITLE
DOC: update copyright statements in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright © 2021 Quansight Labs <flains@quansight.com>
-Copyright © 2021 Filipe Laíns <filipe.lains@gmail.com>
+Copyright © 2022 the meson-python contributors
+Copyright © 2021 Quansight Labs and Filipe Laíns
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
Addresses the licensing part of gh-182.

[ci skip]

@lithomas1 please have a look, I hope this addresses your comments around copyright.

@FFY00 for the two changes I made to the old attribution:
- I combined the two lines for Quansight Labs and your name, because it seems like the common practice is to have the same date range combined on a single line
- and removed the email addresses because that seems unusual to have and subject to change. I'm sure we don't want/need the Quansight Labs email address there. For yours, I'd suggest it's better to get it from the commit log or your GitHub profile in case anyone wants to get in touch. But let me know if you prefer to keep it.
    - Also to clarify for the record, I believe your name is separately listed because you reused some code that you had written before you joined Quansight Labs.