### PR TITLE
TST: Fix test packages

### DIFF
--- a/tests/packages/link-against-local-lib/meson.build
+++ b/tests/packages/link-against-local-lib/meson.build
@@ -8,13 +8,11 @@ example_lib = shared_library(
     install: true,
 )
 
-py_dep = dependency('python3')
 py_mod = import('python')
 py = py_mod.find_installation()
 
 py.extension_module(
     'example', 'examplemod.c',
-    dependencies: py_dep,
     link_with: example_lib,
     install: true,
 )

--- a/tests/packages/purelib-and-platlib/meson.build
+++ b/tests/packages/purelib-and-platlib/meson.build
@@ -3,13 +3,11 @@ project(
     version: '1.0.0',
 )
 
-py_dep = dependency('python3')
 py_mod = import('python')
 py = py_mod.find_installation()
 
 py.install_sources('pure.py')
 py.extension_module(
     'plat', 'plat.c',
-    dependencies: py_dep,
     install: true,
 )

--- a/tests/packages/scipy-like/meson.build
+++ b/tests/packages/scipy-like/meson.build
@@ -5,7 +5,6 @@ project('scipy-like',
 
 py_mod = import('python')
 py = py_mod.find_installation()
-py3_dep = py.dependency()
 
 cc = meson.get_compiler('c')
 is_windows = host_machine.system() == 'windows'

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -192,7 +192,7 @@ def test_interpreter_abi_tag(wheel_purelib_and_platlib):
     strict=True,
 )
 def test_local_lib(virtual_env, wheel_link_against_local_lib):
-    subprocess.check_call([virtual_env, '-m', 'pip', 'install', wheel_link_against_local_lib])
+    subprocess.check_call([virtual_env, '-m', 'pip', '--disable-pip-version-check', 'install', wheel_link_against_local_lib])
     assert subprocess.check_output([
         virtual_env, '-c', 'import example; print(example.example_sum(1, 2))'
     ]).decode().strip() == '3'

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -187,11 +187,8 @@ def test_interpreter_abi_tag(wheel_purelib_and_platlib):
 
 @pytest.mark.skipif(platform.system() != 'Linux', reason='Unsupported on this platform for now')
 @pytest.mark.xfail(
-    (
-        (sys.version_info >= (3, 9) or platform.python_implementation() == 'PyPy')
-        and os.environ.get('GITHUB_ACTIONS') == 'true'
-    ),
-    reason='github actions',
+    platform.python_implementation() == 'PyPy',
+    reason='venv test fixture does not work with PyPy',
     strict=True,
 )
 def test_local_lib(virtual_env, wheel_link_against_local_lib):


### PR DESCRIPTION
In some of the test packages, the Python library is looked up incorrectly using dependency('python3') while the correct way is to use import('python').find_installation().dependency().

The correct lookup method could be used, but since Meson 0.63.0 python extension modules implicitly depend on the Python library and meson-python requires Meson 0.63.3. Just drop the explicit dependency.