### PR TITLE
CI: add pass jobs for both workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,3 +29,9 @@ jobs:
 
       - name: Run mypy
         run: mypy -p mesonpy
+
+  checks-pass:
+    needs: [mypy]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All jobs passed"

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -124,3 +124,9 @@ jobs:
       # 'Package "sage-docker-..." is already associated with another repository.'
       docker_push_repository: ghcr.io/${{ github.repository }}/meson-python-
     needs: [dist]
+
+  sage-pass:
+    needs: [linux]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All jobs passed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,3 +235,9 @@ jobs:
           flags: tests
           env_vars: PYTHON
           name: homebrew-${{ matrix.python }}
+
+  tests-pass:
+    needs: [test, cygwin, pyston, homebrew]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All jobs passed"


### PR DESCRIPTION
This should make it easier to work with CI required jobs. There are now just three required jobs: `checks-pass`, `sage-pass` and `tests-pass`.
