### PR TITLE
MAINT: rename the pyproject.toml tool config table to meson-python

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -625,11 +625,11 @@ class Project():
 
     def _get_config_key(self, key: str) -> Any:
         value: Any = self._config
-        for part in f'tool.mesonpy.{key}'.split('.'):
+        for part in f'tool.meson-python.{key}'.split('.'):
             if not isinstance(value, Mapping):
                 raise ConfigError(
                     f'Found unexpected value in `{part}` when looking for '
-                    f'config key `tool.mesonpy.{key}` (`{value}`)'
+                    f'config key `tool.meson-python.{key}` (`{value}`)'
                 )
             value = value.get(part, {})
         return value

--- a/tests/packages/user-args/pyproject.toml
+++ b/tests/packages/user-args/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = 'mesonpy'
 requires = ['meson-python']
 
-[tool.mesonpy.args]
+[tool.meson-python.args]
 dist = ['config-dist']
 setup = ['config-setup']
 compile = ['config-compile']


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>