### PR TITLE
ENH: drop dependency on wheel

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,5 +13,6 @@ py.install_sources(
   'mesonpy/_elf.py',
   'mesonpy/_tags.py',
   'mesonpy/_util.py',
+  'mesonpy/_wheelfile.py',
   subdir: 'mesonpy',
 )

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -46,13 +46,13 @@ import mesonpy._compat
 import mesonpy._elf
 import mesonpy._tags
 import mesonpy._util
+import mesonpy._wheelfile
 
 from mesonpy._compat import Collection, Iterator, Literal, Mapping, Path
 
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import pyproject_metadata  # noqa: F401
-    import wheel.wheelfile  # noqa: F401
 
 
 if sys.version_info >= (3, 8):
@@ -82,7 +82,6 @@ class _depstr:
     need at runtime. Having them in one place makes it easier to update.
     """
     patchelf = 'patchelf >= 0.11.0'
-    wheel = 'wheel >= 0.36.0'  # noqa: F811
     ninja = f'ninja >= {_NINJA_REQUIRED_VERSION}'
 
 
@@ -455,7 +454,7 @@ class _WheelBuilder():
 
     def _install_path(
         self,
-        wheel_file: wheel.wheelfile.WheelFile,  # type: ignore[name-defined]
+        wheel_file: mesonpy._wheelfile.WheelFile,
         counter: mesonpy._util.CLICounter,
         origin: Path,
         destination: pathlib.Path,
@@ -498,13 +497,11 @@ class _WheelBuilder():
             wheel_file.write(origin, location)
 
     def build(self, directory: Path) -> pathlib.Path:
-        import wheel.wheelfile
-
         self._project.build()  # ensure project is built
 
         wheel_file = pathlib.Path(directory, f'{self.name}.whl')
 
-        with wheel.wheelfile.WheelFile(wheel_file, 'w') as whl:
+        with mesonpy._wheelfile.WheelFile(wheel_file, 'w') as whl:
             # add metadata
             whl.writestr(f'{self.distinfo_dir}/METADATA', self._project.metadata)
             whl.writestr(f'{self.distinfo_dir}/WHEEL', self.wheel)
@@ -1009,7 +1006,7 @@ def build_sdist(
 def get_requires_for_build_wheel(
     config_settings: Optional[Dict[str, str]] = None,
 ) -> List[str]:
-    dependencies = [_depstr.wheel]
+    dependencies = []
 
     if _env_ninja_command() is None:
         dependencies.append(_depstr.ninja)

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -800,9 +800,8 @@ class Project():
         assert isinstance(version, str)
         return version
 
-    @property
-    @functools.lru_cache(maxsize=1)
-    def metadata(self) -> bytes:  # noqa: C901
+    @cached_property
+    def metadata(self) -> bytes:
         """Project metadata."""
         # the rest of the keys are only available when using PEP 621 metadata
         if not self.pep621:
@@ -896,8 +895,8 @@ class Project():
             pkginfo_info = tarfile.TarInfo(f'{dist_name}/PKG-INFO')
             if mtime:
                 pkginfo_info.mtime = mtime
-            pkginfo_info.size = len(self.metadata)  # type: ignore[arg-type]
-            tar.addfile(pkginfo_info, fileobj=io.BytesIO(self.metadata))  # type: ignore[arg-type]
+            pkginfo_info.size = len(self.metadata)
+            tar.addfile(pkginfo_info, fileobj=io.BytesIO(self.metadata))
 
         return sdist
 

--- a/mesonpy/_wheelfile.py
+++ b/mesonpy/_wheelfile.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: MIT
+
+import base64
+import csv
+import hashlib
+import io
+import os
+import re
+import stat
+import time
+import zipfile
+
+from types import TracebackType
+from typing import List, Optional, Tuple, Type, Union
+
+
+Path = Union[str, os.PathLike]
+
+
+MIN_TIMESTAMP = 315532800  # 1980-01-01 00:00:00 UTC
+WHEEL_FILENAME_REGEX = re.compile(r'^(?P<name>[^-]+)-(?P<version>[^-]+)(:?-(?P<build>[^-]+))?-(?P<tag>[^-]+-[^-]+-[^-]+).whl$')
+
+
+def _b64encode(data: bytes) -> bytes:
+    return base64.urlsafe_b64encode(data).rstrip(b'=')
+
+
+class WheelFile:
+    """Implement the wheel package binary distribution format.
+
+    https://packaging.python.org/en/latest/specifications/binary-distribution-format/
+    """
+    def __new__(cls, filename: Path, mode: str = 'r', compression: int = zipfile.ZIP_DEFLATED) -> 'WheelFile':
+        if mode == 'w':
+            return super().__new__(WheelFileWriter)
+        raise NotImplementedError
+
+    @staticmethod
+    def timestamp(mtime: Optional[float] = None) -> Tuple[int, int, int, int, int, int]:
+        timestamp = int(os.environ.get('SOURCE_DATE_EPOCH', mtime or time.time()))
+        # The ZIP file format does not support timestamps before 1980.
+        timestamp = max(timestamp, MIN_TIMESTAMP)
+        return time.gmtime(timestamp)[0:6]
+
+    @staticmethod
+    def hash(data: bytes) -> str:
+        return 'sha256=' + _b64encode(hashlib.sha256(data).digest()).decode('ascii')
+
+    def writestr(self, zinfo_or_arcname: Union[str, zipfile.ZipInfo], data: bytes) -> None:
+        raise NotImplementedError
+
+    def write(self, filename: Path, arcname: Optional[str] = None) -> None:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+    def __enter__(self) -> 'WheelFile':
+        return self
+
+    def __exit__(self, exc_type: Type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:
+        self.close()
+
+
+class WheelFileWriter(WheelFile):
+    def __init__(self, filepath: Path, mode: str, compression: int = zipfile.ZIP_DEFLATED):
+        filename = os.path.basename(filepath)
+        match = WHEEL_FILENAME_REGEX.match(filename)
+        if not match:
+            raise ValueError(f'invalid wheel filename: {filename!r}')
+        self.name = match.group('name')
+        self.version = match.group('version')
+        self.entries: List[Tuple[str, str, int]] = []
+        self.archive = zipfile.ZipFile(filepath, mode='w', compression=compression, allowZip64=True)
+
+    def writestr(self, zinfo_or_arcname: Union[str, zipfile.ZipInfo], data: bytes) -> None:
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+        if isinstance(zinfo_or_arcname, zipfile.ZipInfo):
+            zinfo = zinfo_or_arcname
+        else:
+            zinfo = zipfile.ZipInfo(zinfo_or_arcname, date_time=self.timestamp())
+            zinfo.external_attr = 0o664 << 16
+        self.archive.writestr(zinfo, data)
+        self.entries.append((zinfo.filename, self.hash(data), len(data)))
+
+    def write(self, filename: Path, arcname: Optional[str] = None) -> None:
+        with open(filename, 'rb') as f:
+            st = os.fstat(f.fileno())
+            data = f.read()
+        zinfo = zipfile.ZipInfo(arcname or str(filename), date_time=self.timestamp(st.st_mtime))
+        zinfo.external_attr = (stat.S_IMODE(st.st_mode) | stat.S_IFMT(st.st_mode)) << 16
+        self.writestr(zinfo, data)
+
+    def close(self) -> None:
+        record = f'{self.name}-{self.version}.dist-info/RECORD'
+        data = io.StringIO()
+        writer = csv.writer(data, delimiter=',', quotechar='"', lineterminator='\n')
+        writer.writerows(self.entries)
+        writer.writerow((record, '', ''))
+        zi = zipfile.ZipInfo(record, date_time=self.timestamp())
+        zi.external_attr = 0o664 << 16
+        self.archive.writestr(zi, data.getvalue())
+        self.archive.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,8 +141,6 @@ def pep518_wheelhouse(tmpdir_factory):
     # the pip cache are used when available.
     packages = [
         meson_python,
-        'build',
-        'wheel',
     ]
     subprocess.run([sys.executable, '-m', 'pip', 'wheel', '--wheel-dir', str(wheelhouse), *packages], check=True)
     return str(wheelhouse)

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -36,7 +36,7 @@ def test_get_requires_for_build_wheel(monkeypatch, package, system_patchelf, nin
     monkeypatch.setattr(shutil, 'which', which)
     monkeypatch.setattr(subprocess, 'run', run)
 
-    expected = {mesonpy._depstr.wheel}
+    expected = set()
 
     ninja_available = ninja is not None and [int(x) for x in ninja.split('.')] >= [1, 8, 2]
 

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -1,0 +1,36 @@
+import time
+
+import wheel.wheelfile
+
+import mesonpy._wheelfile
+
+
+def test_basic(tmp_path):
+    path = tmp_path / 'test-1.0-py3-any-none.whl'
+    bar = tmp_path / 'bar'
+    open(bar, 'wb').write(b'bar')
+    with mesonpy._wheelfile.WheelFile(path, 'w') as w:
+        assert w.name == 'test'
+        assert w.version == '1.0'
+        w.writestr('foo', b'test')
+        w.write(bar, 'bar')
+    with wheel.wheelfile.WheelFile(path, 'r') as w:
+        assert set(w.namelist()) == {'foo', 'bar', 'test-1.0.dist-info/RECORD'}
+        w.open('foo').read() == b'test'
+        w.open('bar').read() == b'bar'
+
+
+def test_source_date_epoch(tmp_path, monkeypatch):
+    path = tmp_path / 'test-1.0-py3-any-none.whl'
+    epoch = 1668871912
+    # The ZIP file format timestamps have 2 seconds resolution.
+    assert epoch % 2 == 0
+    monkeypatch.setenv('SOURCE_DATE_EPOCH', str(epoch))
+    bar = tmp_path / 'bar'
+    open(bar, 'wb').write(b'bar')
+    with mesonpy._wheelfile.WheelFile(path, 'w') as w:
+        w.writestr('foo', b'test')
+        w.write(bar, 'bar')
+    with wheel.wheelfile.WheelFile(path, 'r') as w:
+        for entry in w.infolist():
+            assert entry.date_time == time.gmtime(epoch)[:6]


### PR DESCRIPTION
The wheel package does not offer a public API.  Implement a minimal wheel file format writer to replace the use of the wheel package. This also reduces the number of external dependencies and will help a future integration of meson-python into Meson.  The produced wheel files are validated in the test suite inspecting them with the wheel package reader.

Fixes https://github.com/mesonbuild/meson-python/issues/192.