### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: docs
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+      - release-*
+    paths:
+      - docs/**
+      - CHANGELOG.rst
+      - README.md
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - uses: actions/checkout@v3
+      - run: python -m pip install .[docs]
+      - run: python -m sphinx -W -b html docs/ build/html/

--- a/.github/workflows/sage.yml
+++ b/.github/workflows/sage.yml
@@ -64,6 +64,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    outputs:
+      systems: ${{ steps.push-to-main-systems.outputs.systems }} ${{ steps.pull-request-systems.outputs.systems }}
     steps:
       - name: Check out ${{ env.SPKG }}
         uses: actions/checkout@v3
@@ -83,7 +85,34 @@ jobs:
           && echo "sed -i.bak \"/pushdef.*LT_VERSION/s/3[0-9.]*/4/\" ../build/pkgs/python3/spkg-configure.m4" >> upstream/update-pkgs.sh \
           && echo "sed -i.bak \"/export.*proxy/d\" ../build/bin/sage-spkg" >> upstream/update-pkgs.sh \
           && ls -l upstream/
-      - uses: actions/upload-artifact@v2
+      - name: System factors for pull requests
+        # See https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml for available systems
+        id: pull-request-systems
+        if: ${{ github.event_name == 'pull_request' }}
+        run: >-
+          echo 'systems=[
+          "archlinux-latest",
+          "conda-forge",
+          ]' >> $GITHUB_OUTPUT
+      - name: System factors for push to main
+        # See https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml for available systems
+        id: push-to-main-systems
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: >-
+          echo 'systems=[
+          "debian-bullseye",
+          "fedora-36",
+          "centos-stream-8-python3.9",
+          "gentoo-python3.9",
+          "archlinux-latest",
+          "opensuse-15.4-gcc_11-python3.10",
+          "opensuse-tumbleweed-python3.10",
+          "conda-forge",
+          "archlinux-latest",
+          "conda-forge",
+          ]' >> $GITHUB_OUTPUT
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
         with:
           path: upstream
           name: upstream
@@ -96,19 +125,9 @@ jobs:
       # Reduced list of systems to test: Only those that bring python >= 3.8
       # Full list at https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
       # See also https://github.com/sagemath/sage/blob/develop/tox.ini
-      tox_system_factors: >-
-          ["debian-bullseye",
-           "fedora-36",
-           "centos-stream-8-python3.9",
-           "gentoo-python3.9",
-           "archlinux-latest",
-           "opensuse-15.4-gcc_11-python3.10",
-           "opensuse-tumbleweed-python3.10",
-           "conda-forge",
-           ]
+      tox_system_factors: ${{ needs.build.outputs.systems }}
       tox_packages_factors: >-
-          ["minimal-develop",
-           ]
+        ["minimal-develop",]
       # Extra packages to install as system packages
       extra_sage_packages: "liblzma bzip2 libffi libpng python3 ninja_build"
       # Sage distribution packages to build

--- a/.github/workflows/sage.yml
+++ b/.github/workflows/sage.yml
@@ -112,7 +112,7 @@ jobs:
           "conda-forge",
           ]' >> $GITHUB_OUTPUT
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: upstream
           name: upstream

--- a/.github/workflows/sage.yml
+++ b/.github/workflows/sage.yml
@@ -62,7 +62,7 @@ env:
 
 jobs:
 
-  dist:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out ${{ env.SPKG }}
@@ -88,7 +88,7 @@ jobs:
           path: upstream
           name: upstream
 
-  linux:
+  test:
     # https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
     # Use branch u/mkoeppe/numpy_1_23_x__scipy_1_9_x for a fix for uppercase github repo names (FFY00)
     uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@u/mkoeppe/numpy_1_23_x__scipy_1_9_x
@@ -126,10 +126,10 @@ jobs:
       # We prefix the image name with the SPKG name ("meson-python-") to avoid the error
       # 'Package "sage-docker-..." is already associated with another repository.'
       docker_push_repository: ghcr.io/${{ github.repository }}/meson-python-
-    needs: [dist]
+    needs: [build]
 
   # sage-pass:
-  #   needs: [linux]
+  #   needs: [test]
   #   runs-on: ubuntu-latest
   #   steps:
   #     - run: echo "All jobs passed"

--- a/.github/workflows/sage.yml
+++ b/.github/workflows/sage.yml
@@ -78,13 +78,19 @@ jobs:
           python3 -m pip install --user build
       - name: Run make dist, prepare upstream artifact
         run: |
-          (cd build/pkgs/${{ env.SPKG }}/src && python3 -m build --sdist .) \
-          && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/dist/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
-          && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=standard" > upstream/update-pkgs.sh \
-          && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
-          && echo "sed -i.bak \"/pushdef.*LT_VERSION/s/3[0-9.]*/4/\" ../build/pkgs/python3/spkg-configure.m4" >> upstream/update-pkgs.sh \
-          && echo "sed -i.bak \"/export.*proxy/d\" ../build/bin/sage-spkg" >> upstream/update-pkgs.sh \
-          && ls -l upstream/
+          pushd build/pkgs/${{ env.SPKG }}/src
+          python3 -m build --sdist .
+          popd
+          mkdir -p upstream
+          cp build/pkgs/${{ env.SPKG }}/src/dist/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz
+          echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=standard" > upstream/update-pkgs.sh
+          if [ -n "${{ env.REMOVE_PATCHES }}" ]
+          then
+            echo "(cd ../build/pkgs/${{ env.SPKG }}/patches rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh
+          fi
+          echo "sed -i.bak \"/pushdef.*LT_VERSION/s/3[0-9.]*/4/\" ../build/pkgs/python3/spkg-configure.m4" >> upstream/update-pkgs.sh
+          echo "sed -i.bak \"/export.*proxy/d\" ../build/bin/sage-spkg" >> upstream/update-pkgs.sh
+          ls -l upstream
       - name: System factors for pull requests
         # See https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml for available systems
         id: pull-request-systems
@@ -122,14 +128,13 @@ jobs:
     # Use branch u/mkoeppe/numpy_1_23_x__scipy_1_9_x for a fix for uppercase github repo names (FFY00)
     uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@u/mkoeppe/numpy_1_23_x__scipy_1_9_x
     with:
-      # Reduced list of systems to test: Only those that bring python >= 3.8
-      # Full list at https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
-      # See also https://github.com/sagemath/sage/blob/develop/tox.ini
       tox_system_factors: ${{ needs.build.outputs.systems }}
       tox_packages_factors: >-
         ["minimal-develop",]
-      # Extra packages to install as system packages
-      extra_sage_packages: "liblzma bzip2 libffi libpng python3 ninja_build"
+      # Extra system packages to install. See available packages at
+      # https://github.com/sagemath/sage/tree/develop/build/pkgs
+      # liblzma, bzip2, and libffi are python3 dependencies.
+      extra_sage_packages: "liblzma bzip2 libffi python3 ninja_build"
       # Sage distribution packages to build
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="meson_python" python_build meson_python
       # Standard setting: Test the current beta release of Sage:

--- a/.github/workflows/sage.yml
+++ b/.github/workflows/sage.yml
@@ -128,8 +128,8 @@ jobs:
       docker_push_repository: ghcr.io/${{ github.repository }}/meson-python-
     needs: [dist]
 
-  sage-pass:
-    needs: [linux]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "All jobs passed"
+  # sage-pass:
+  #   needs: [linux]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: echo "All jobs passed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,20 @@ jobs:
           - macos
           - windows
         python:
-          - 'pypy-3.8'
-          - 'pypy-3.9'
           - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
           - '3.11'
+        include:
+          # Skip this interpreter version.
+          # - os: ubuntu
+          #   python: 'pypy-3.8'
+          - os: ubuntu
+            python: 'pypy-3.9'
+          - os: ubuntu
+            python: '3.8'
+          - os: ubuntu
+            python: '3.9'
+          - os: ubuntu
+            python: '3.10'
 
     steps:
       - name: Checkout
@@ -188,9 +195,6 @@ jobs:
       matrix:
         python:
           - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
           - '3.11'
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,6 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}-latest
-    env:
-      FORCE_COLOR: true
     strategy:
       fail-fast: false
       matrix:
@@ -70,8 +68,6 @@ jobs:
 
   cygwin:
     runs-on: windows-latest
-    env:
-      FORCE_COLOR: true
     strategy:
       fail-fast: false
       matrix:
@@ -152,8 +148,6 @@ jobs:
 
   pyston:
     runs-on: ubuntu-20.04
-    env:
-      FORCE_COLOR: true
     strategy:
       fail-fast: false
       matrix:
@@ -189,8 +183,6 @@ jobs:
 
   homebrew:
     runs-on: macos-latest
-    env:
-      FORCE_COLOR: true
     strategy:
       fail-fast: false
       matrix:
@@ -242,8 +234,6 @@ jobs:
 
   mypy:
     runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: true
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,8 +253,8 @@ jobs:
       - name: Run mypy
         run: mypy -p mesonpy
 
-  tests-pass:
-    needs: [test, cygwin, pyston, homebrew, mypy]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "All jobs passed"
+  # tests-pass:
+  #   needs: [test, cygwin, pyston, homebrew, mypy]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: echo "All jobs passed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,7 +235,8 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
The main goal here is to cut down the total number of jobs we run from 41 to to something more sensible.

I got them down to:

- CPython 3.7 and 3.11, and on Windows, macOS, and Ubuntu: 6 jobs
- CPython 3.8, 3.9, 3.10, and PyPy 3.9 on Ubuntu: 4 jobs
- CPython 3.9 in Cygwin: 1 job
- Pyston 3.8 on Ubuntu: 1 job
- CPython 3.7 and 3.11 on Homebrew: 2 jobs
- a mypy job,
- the precommit tests,
- the Sage build job and the 8 Sage test jobs.

That's 25 jobs total. 

I've experimented with running the Sage workflow only of the tests workflow succeeds but that has the annoying consequence of removing the Sage workflow test results from the PR view. The only way I know to avoid this is to have the Sage jobs defined in the same workflow as the other tests, but it does not seem very tidy.