### PR TITLE
CI: Use sage develop branch

### DIFF
--- a/.github/workflows/sage.yml
+++ b/.github/workflows/sage.yml
@@ -133,7 +133,7 @@ jobs:
       # Extra system packages to install. See available packages at
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
       # liblzma, bzip2, and libffi are python3 dependencies.
-      extra_sage_packages: "liblzma bzip2 libffi python3 ninja_build"
+      extra_sage_packages: "patch liblzma bzip2 libffi python3 ninja_build"
       # Sage distribution packages to build
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="meson_python" python_build meson_python
       sage_repo: sagemath/sage

--- a/.github/workflows/sage.yml
+++ b/.github/workflows/sage.yml
@@ -125,8 +125,7 @@ jobs:
 
   test:
     # https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
-    # Use branch u/mkoeppe/numpy_1_23_x__scipy_1_9_x for a fix for uppercase github repo names (FFY00)
-    uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@u/mkoeppe/numpy_1_23_x__scipy_1_9_x
+    uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@develop
     with:
       tox_system_factors: ${{ needs.build.outputs.systems }}
       tox_packages_factors: >-
@@ -137,18 +136,11 @@ jobs:
       extra_sage_packages: "liblzma bzip2 libffi python3 ninja_build"
       # Sage distribution packages to build
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="meson_python" python_build meson_python
-      # Standard setting: Test the current beta release of Sage:
       sage_repo: sagemath/sage
       sage_ref: develop
       upstream_artifact: upstream
       sage_trac_git: https://github.com/sagemath/sagetrac-mirror.git
-      # Temporarily test on the branch from sage ticket https://trac.sagemath.org/ticket/34081 (scipy 1.9.x)
-      # (this is a no-op after that ticket is merged)
-      sage_trac_ticket: 34081
-      # Docker targets (stages) to tag
       docker_targets: "with-targets"
-      # We prefix the image name with the SPKG name ("meson-python-") to avoid the error
-      # 'Package "sage-docker-..." is already associated with another repository.'
       docker_push_repository: ghcr.io/${{ github.repository }}/meson-python-
     needs: [build]
 


### PR DESCRIPTION
The meson build infrastructure has been merged in Sage 9.8.beta4, so we can now test with the `develop` branch of Sage (which updates on every beta release.)

Also add another system package so that Sage does not have to build it from source.