### PR TITLE
ENH: support setuptools-style cross compilation on macOS

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -652,7 +652,7 @@ class Project():
 
     def _meson(self, *args: str) -> None:
         """Invoke Meson."""
-        with mesonpy._util.cd(self._build_dir):
+        with mesonpy._util.chdir(self._build_dir):
             return self._proc('meson', *args)
 
     def _configure(self, reconfigure: bool = False) -> None:

--- a/mesonpy/_tags.py
+++ b/mesonpy/_tags.py
@@ -84,7 +84,19 @@ def get_abi_tag() -> str:
 
 
 def _get_macosx_platform_tag() -> str:
-    ver, x, arch = platform.mac_ver()
+    ver, _, arch = platform.mac_ver()
+
+    # Override the architecture with the one provided in the
+    # _PYTHON_HOST_PLATFORM environment variable.  This environment
+    # variable affects the sysconfig.get_platform() return value and
+    # is used to cross-compile python extensions on macOS for a
+    # different architecture.  We base the platform tag computation on
+    # platform.mac_ver() but respect the content of the environment
+    # variable.
+    try:
+        arch = os.environ.get('_PYTHON_HOST_PLATFORM', '').split('-')[2]
+    except IndexError:
+        pass
 
     # Override the macOS version if one is provided via the
     # MACOS_DEPLOYMENT_TARGET environment variable.

--- a/mesonpy/_util.py
+++ b/mesonpy/_util.py
@@ -15,12 +15,12 @@ from mesonpy._compat import Iterable, Iterator, Path
 
 
 @contextlib.contextmanager
-def cd(path: Path) -> Iterator[None]:
+def chdir(path: Path) -> Iterator[Path]:
     """Context manager helper to change the current working directory -- cd."""
     old_cwd = os.getcwd()
     os.chdir(os.fspath(path))
     try:
-        yield
+        yield path
     finally:
         os.chdir(old_cwd)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ import pytest
 
 import mesonpy
 
+from mesonpy._util import chdir
+
 
 def adjust_packaging_platform_tag(platform: str) -> str:
     if platform.startswith(('manylinux', 'musllinux')):
@@ -41,16 +43,6 @@ def adjust_packaging_platform_tag(platform: str) -> str:
 
 
 package_dir = pathlib.Path(__file__).parent / 'packages'
-
-
-@contextlib.contextmanager
-def chdir(path):
-    current = os.getcwd()
-    os.chdir(path)
-    try:
-        yield path
-    finally:
-        os.chdir(current)
 
 
 @contextlib.contextmanager

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,7 +6,7 @@ import pytest
 
 import mesonpy
 
-from .conftest import chdir
+from mesonpy._util import chdir
 
 
 examples_dir = pathlib.Path(__file__).parent.parent / 'docs' / 'examples'

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -10,7 +10,9 @@ import pytest
 
 import mesonpy
 
-from .conftest import chdir, package_dir
+from mesonpy._util import chdir
+
+from .conftest import package_dir
 
 
 @pytest.mark.parametrize('package', ['pure', 'library'])

--- a/tests/test_pep518.py
+++ b/tests/test_pep518.py
@@ -3,7 +3,9 @@ import sys
 
 import pytest
 
-from .conftest import chdir, in_git_repo_context, package_dir
+from mesonpy._util import chdir
+
+from .conftest import in_git_repo_context, package_dir
 
 
 @pytest.mark.usefixtures('pep518')

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -43,6 +43,14 @@ def test_macos_platform_tag(monkeypatch):
             assert next(packaging.tags.mac_platforms((major, minor))) == mesonpy._tags.get_platform_tag()
 
 
+@pytest.mark.skipif(platform.system() != 'Darwin', reason='macOS specific test')
+def test_python_host_platform(monkeypatch):
+    monkeypatch.setenv('_PYTHON_HOST_PLATFORM', 'macosx-12.0-arm64')
+    assert mesonpy._tags.get_platform_tag().endswith('arm64')
+    monkeypatch.setenv('_PYTHON_HOST_PLATFORM', 'macosx-11.1-x86_64')
+    assert mesonpy._tags.get_platform_tag().endswith('x86_64')
+
+
 def wheel_builder_test_factory(monkeypatch, content):
     files = defaultdict(list)
     files.update({key: [(pathlib.Path(x), os.path.join('build', x)) for x in value] for key, value in content.items()})


### PR DESCRIPTION
Use sysconfig.get_platform() instead of platform.mac_ver() to base the platform tag computation.  The ability to overwrite the value returned by former via the _PYTHON_HOST_PLATFORM environment variable is used in macOS extension modules cross-compilation.

See #222 for background.