### PR TITLE
ENH: include allowed keys in error message

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -966,8 +966,15 @@ def _project(config_settings: Optional[Dict[Any, Any]]) -> Iterator[Project]:
     meson_args_cli_keys = tuple(f'{key}-args' for key in meson_args_keys)
 
     for key in config_settings:
-        if key not in ('builddir', *meson_args_cli_keys):
-            raise ConfigError(f'Unknown config setting: {key}')
+        known_keys = ('builddir', *meson_args_cli_keys)
+        if key not in known_keys:
+            import difflib
+            matches = difflib.get_close_matches(key, known_keys, n=3)
+            if len(matches):
+                postfix = f'Did you mean one of: {matches}'
+            else:
+                postfix = 'There are no close valid keys.'
+            raise ConfigError(f'Unknown config setting: {key!r}.  {postfix}')
 
     for key in meson_args_cli_keys:
         _validate_string_collection(key)

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -54,9 +54,22 @@ def test_get_requires_for_build_wheel(monkeypatch, package, system_patchelf, nin
 
 
 def test_invalid_config_settings(package_pure, tmp_path_session):
-    raises_error = pytest.raises(mesonpy.ConfigError, match='Unknown config setting: invalid')
+    raises_error = pytest.raises(mesonpy.ConfigError, match="Unknown config setting: 'invalid'")
 
     with raises_error:
         mesonpy.build_sdist(tmp_path_session, {'invalid': ()})
     with raises_error:
         mesonpy.build_wheel(tmp_path_session, {'invalid': ()})
+
+
+def test_invalid_config_settings_suggest(package_pure, tmp_path_session):
+    raises_error = pytest.raises(
+        mesonpy.ConfigError,
+        match='Did you mean one of: .*setup-args'
+    )
+
+    with raises_error:
+        mesonpy.build_sdist(tmp_path_session, {'setup_args': ()})
+
+    with raises_error:
+        mesonpy.build_wheel(tmp_path_session, {'setup_args': ()})


### PR DESCRIPTION
This adds the allowed keys to the error message (I was trying with `_` instead of `-` in a name, this would have cut my debugging time to seconds rather than a few minutes).