### PR TITLE
ENH: drop typing-extensions dependency

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -31,17 +31,13 @@ import textwrap
 import typing
 import warnings
 
-from typing import (
-    Any, Callable, ClassVar, DefaultDict, Dict, List, Optional, Sequence, Set,
-    TextIO, Tuple, Type, TypeVar, Union
-)
+from typing import Dict
 
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
 else:
     import tomllib
-
 
 import mesonpy._compat
 import mesonpy._elf
@@ -51,16 +47,37 @@ import mesonpy._util
 import mesonpy._wheelfile
 
 from mesonpy._compat import (
-    Collection, Iterable, Iterator, Literal, Mapping, ParamSpec, Path,
-    cached_property, read_binary, typing_get_args
+    Collection, Iterable, Mapping, cached_property, read_binary
 )
 
 
 if typing.TYPE_CHECKING:  # pragma: no cover
+    from typing import (
+        Any, Callable, ClassVar, DefaultDict, List, Optional, Sequence, Set,
+        TextIO, Tuple, Type, TypeVar, Union
+    )
+
     import pyproject_metadata  # noqa: F401
+
+    from mesonpy._compat import Iterator, Literal, ParamSpec, Path
+
+    P = ParamSpec('P')
+    T = TypeVar('T')
 
 
 __version__ = '0.13.0.dev0'
+
+
+# XXX: Once Python 3.8 is our minimum supported version, get rid of
+#      meson_args_keys and use typing.get_args(MesonArgsKeys) instead.
+
+# Keep both definitions in sync!
+_MESON_ARGS_KEYS = ['dist', 'setup', 'compile', 'install']
+if typing.TYPE_CHECKING:
+    MesonArgsKeys = Literal['dist', 'setup', 'compile', 'install']
+    MesonArgs = Mapping[MesonArgsKeys, List[str]]
+else:
+    MesonArgs = None
 
 
 _COLORS = {
@@ -631,10 +648,6 @@ class _WheelBuilder():
         return wheel_file
 
 
-MesonArgsKeys = Literal['dist', 'setup', 'compile', 'install']
-MesonArgs = Mapping[MesonArgsKeys, List[str]]
-
-
 class Project():
     """Meson project wrapper to generate Python artifacts."""
 
@@ -718,7 +731,7 @@ class Project():
         # XXX: We should validate the user args to make sure they don't conflict with ours.
 
         self._check_for_unknown_config_keys({
-            'args': typing_get_args(MesonArgsKeys),
+            'args': _MESON_ARGS_KEYS,
         })
 
         # meson arguments from the command line take precedence over
@@ -1109,7 +1122,7 @@ def _project(config_settings: Optional[Dict[Any, Any]]) -> Iterator[Project]:
             s = ', '.join(f'"{item}" ({type(item)})' for item in problematic_items)
             raise ConfigError(f'Configuration entries for "{key}" must be strings but contain: {s}')
 
-    meson_args_keys = typing_get_args(MesonArgsKeys)
+    meson_args_keys = _MESON_ARGS_KEYS
     meson_args_cli_keys = tuple(f'{key}-args' for key in meson_args_keys)
 
     for key in config_settings:
@@ -1160,10 +1173,6 @@ def _env_ninja_command(*, version: str = _NINJA_REQUIRED_VERSION) -> Optional[pa
         return pathlib.Path(ninja_path)
 
     return None
-
-
-P = ParamSpec('P')
-T = TypeVar('T')
 
 
 def _pyproject_hook(func: Callable[P, T]) -> Callable[P, T]:

--- a/mesonpy/_compat.py
+++ b/mesonpy/_compat.py
@@ -2,19 +2,15 @@
 # SPDX-FileCopyrightText: 2021 Quansight, LLC
 # SPDX-FileCopyrightText: 2021 Filipe Laíns <lains@riseup.net>
 
+from __future__ import annotations
+
 import functools
 import importlib.resources
 import os
 import pathlib
 import sys
+import typing
 
-from typing import Union
-
-
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
 
 if sys.version_info >= (3, 9):
     from collections.abc import (
@@ -22,14 +18,6 @@ if sys.version_info >= (3, 9):
     )
 else:
     from typing import Collection, Iterable, Iterator, Mapping, Sequence
-
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-    from typing import get_args as typing_get_args
-else:
-    from typing_extensions import Literal
-    from typing_extensions import get_args as typing_get_args
 
 
 if sys.version_info >= (3, 8):
@@ -45,7 +33,20 @@ else:
     read_binary = importlib.resources.read_binary
 
 
-Path = Union[str, os.PathLike]
+if typing.TYPE_CHECKING:
+    from typing import Union
+
+    if sys.version_info >= (3, 10):
+        from typing import ParamSpec
+    else:
+        from typing_extensions import ParamSpec
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
+
+    Path = Union[str, os.PathLike]
 
 
 # backport og pathlib.Path.is_relative_to
@@ -61,7 +62,6 @@ __all__ = [
     'cached_property',
     'is_relative_to',
     'read_binary',
-    'typing_get_args',
     'Collection',
     'Iterable',
     'Iterator',

--- a/mesonpy/_elf.py
+++ b/mesonpy/_elf.py
@@ -2,12 +2,17 @@
 # SPDX-FileCopyrightText: 2021 Quansight, LLC
 # SPDX-FileCopyrightText: 2021 Filipe Laíns <lains@riseup.net>
 
+from __future__ import annotations
+
 import os
 import subprocess
+import typing
 
-from typing import Optional
 
-from mesonpy._compat import Collection, Path
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from typing import Optional
+
+    from mesonpy._compat import Collection, Path
 
 
 class ELF:

--- a/mesonpy/_introspection.py
+++ b/mesonpy/_introspection.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import sys
 import sysconfig
+import typing
 import warnings
 
-from mesonpy._compat import Mapping
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from mesonpy._compat import Mapping
 
 
 def debian_python() -> bool:

--- a/mesonpy/_tags.py
+++ b/mesonpy/_tags.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import os
 import platform
 import sys
 import sysconfig
+import typing
 
-from typing import Optional, Union
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from typing import Optional, Union
 
 
 # https://peps.python.org/pep-0425/#python-tag

--- a/mesonpy/_util.py
+++ b/mesonpy/_util.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: 2021 Quansight, LLC
 # SPDX-FileCopyrightText: 2021 Filipe Laíns <lains@riseup.net>
 
+from __future__ import annotations
+
 import contextlib
 import gzip
 import os
@@ -9,9 +11,13 @@ import sys
 import tarfile
 import typing
 
-from typing import IO, Optional, Tuple
+from typing import IO
 
-from mesonpy._compat import Iterable, Iterator, Path
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from typing import Optional, Tuple
+
+    from mesonpy._compat import Iterable, Iterator, Path
 
 
 @contextlib.contextmanager

--- a/mesonpy/_wheelfile.py
+++ b/mesonpy/_wheelfile.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import base64
 import csv
 import hashlib
@@ -8,13 +10,15 @@ import os
 import re
 import stat
 import time
+import typing
 import zipfile
 
-from types import TracebackType
-from typing import List, Optional, Tuple, Type, Union
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from types import TracebackType
+    from typing import List, Optional, Tuple, Type, Union
 
-Path = Union[str, os.PathLike]
+    from mesonpy._compat import Path
 
 
 MIN_TIMESTAMP = 315532800  # 1980-01-01 00:00:00 UTC
@@ -55,7 +59,7 @@ class WheelFile:
     def close(self) -> None:
         raise NotImplementedError
 
-    def __enter__(self) -> 'WheelFile':
+    def __enter__(self) -> WheelFile:
         return self
 
     def __exit__(self, exc_type: Type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = [
   'meson>=0.63.3',
   'pyproject-metadata>=0.6.1',
   'tomli>=1.0.0; python_version<"3.11"',
-  'typing-extensions>=3.7.4; python_version<"3.10"',
 ]
 
 [project]
@@ -28,7 +27,6 @@ dependencies = [
   'meson>=0.63.3',
   'pyproject-metadata>=0.6.1', # not a hard dependency, only needed for projects that use PEP 621 metadata
   'tomli>=1.0.0; python_version<"3.11"',
-  'typing-extensions>=3.7.4; python_version<"3.10"',
 ]
 
 dynamic = [
@@ -44,6 +42,7 @@ test = [
   'auditwheel',
   'Cython',
   'wheel',
+  'typing-extensions>=3.7.4; python_version<"3.10"',
 ]
 docs = [
   'furo>=2021.08.31',


### PR DESCRIPTION
~~On top of #251, as it conflicts, and I don't want to have to rebase the PR after that gets merged.~~

As suggested in #248

Pros

- Drop the `typing-extensions` runtime dependency

Cons

- Unknown future, as we rely on `from __future__ import annotations`
- More complexity
- More unnecessary boilerplate
	- This can be avoided by limiting `TYPE_CHECKING` to only when necessary