### PR TITLE
Fix linking against libraries from Meson project on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you have a general question feel free to [start a discussion][new discussion]
 on Github. If you want to report a bug, request a feature, or propose an improvement, feel
 free to open an issue on our [bugtracker][bugtracker].
 
+
 ## Contributing
 
 If you are interested in contributing, please check out

--- a/docs/reference/limitations.rst
+++ b/docs/reference/limitations.rst
@@ -52,13 +52,13 @@ Platform-specific limitations
 =============================
 
 
-Executables with internal dependencies :bdg-warning:`Windows` :bdg-warning:`macOS`
-----------------------------------------------------------------------------------
+Executables with internal dependencies :bdg-warning:`Windows`
+-------------------------------------------------------------
 
 
 If you have an executable that links against a shared library provided by your
-project, on Windows and macOS ``meson-python`` will not be able to correctly
-bundle it into the *wheel*.
+project, on Windows ``meson-python`` will not be able to correctly bundle it
+into the *wheel*.
 
 The executable will be included in the *wheel*, but it
 will not be able to find the project libraries it links against.

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ endif
 py.install_sources(
   'mesonpy/__init__.py',
   'mesonpy/_compat.py',
+  'mesonpy/_dylib.py',
   'mesonpy/_editable.py',
   'mesonpy/_elf.py',
   'mesonpy/_introspection.py',

--- a/mesonpy/_dylib.py
+++ b/mesonpy/_dylib.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import typing
 
+
 if typing.TYPE_CHECKING:
     from typing import Optional
 

--- a/mesonpy/_dylib.py
+++ b/mesonpy/_dylib.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2023 Lars Pastewka <lars.pastewka@imtek.uni-freiburg.de>
 
+from __future__ import annotations
+
 import os
 import subprocess
+import typing
 
-from typing import Optional
+if typing.TYPE_CHECKING:
+    from typing import Optional
 
-from mesonpy._compat import Collection, Path
+    from mesonpy._compat import Collection, Path
 
 
 # This class is modeled after the ELF class in _elf.py

--- a/mesonpy/_dylib.py
+++ b/mesonpy/_dylib.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2023 Lars Pastewka <lars.pastewka@imtek.uni-freiburg.de>
+
+import os
+import subprocess
+
+from typing import Optional
+
+from mesonpy._compat import Collection, Path
+
+
+# This class is modeled after the ELF class in _elf.py
+class Dylib:
+    def __init__(self, path: Path) -> None:
+        self._path = os.fspath(path)
+        self._rpath: Optional[Collection[str]] = None
+        self._needed: Optional[Collection[str]] = None
+
+    def _otool(self, *args: str) -> str:
+        return subprocess.check_output(['otool', *args, self._path], stderr=subprocess.STDOUT).decode()
+
+    def _install_name_tool(self, *args: str) -> str:
+        return subprocess.check_output(['install_name_tool', *args, self._path], stderr=subprocess.STDOUT).decode()
+
+    @property
+    def rpath(self) -> Collection[str]:
+        if self._rpath is None:
+            self._rpath = []
+            # Run otool -l to get the load commands
+            otool_output = self._otool('-l').strip()
+            # Manually parse the output for LC_RPATH
+            rpath_tag = False
+            for line in [x.split() for x in otool_output.split('\n')]:
+                if line == ['cmd', 'LC_RPATH']:
+                    rpath_tag = True
+                elif len(line) >= 2 and line[0] == 'path' and rpath_tag:
+                    self._rpath += [line[1]]
+                    rpath_tag = False
+        return frozenset(self._rpath)
+
+    @rpath.setter
+    def rpath(self, value: Collection[str]) -> None:
+        # We clear all LC_RPATH load commands
+        if self._rpath:
+            for rpath in self._rpath:
+                self._install_name_tool('-delete_rpath', rpath)
+        # We then rewrite the new load commands
+        for rpath in value:
+            self._install_name_tool('-add_rpath', rpath)
+        self._rpath = value


### PR DESCRIPTION
This PR fixes linking against libraries created during the Meson build on macOS. It uses `otool` and `install_name_tool` to update the LC_RPATH load command in the dylib. (This is identical to how the library is patched on Linux.)