### PR TITLE
BUG: fix macOS support for cross-compiling C++

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -682,7 +682,7 @@ class Project():
                     cross_file_data = textwrap.dedent(f'''
                         [binaries]
                         c = ['cc', '-arch', {arch!r}]
-                        cpp = ['cpp', '-arch', {arch!r}]
+                        cpp = ['c++', '-arch', {arch!r}]
                         [host_machine]
                         system = 'Darwin'
                         cpu = {arch!r}


### PR DESCRIPTION
In commit 13c6748a122bf7b5e887451165f66d33618dbe3b support was added for setting up cross file support based on the presence of $ARCHFLAGS, which is something that setuptools supported specifically for macOS.

It writes a Meson cross file out which is mostly correct, but it defines the C++ compiler in terms of the C preprocessor, which doesn't work. Fix this to use the correct program.