### PR TITLE
ENH: change minimal version of pyproject-metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = 'mesonpy'
 backend-path = ['.']
 requires = [
   'meson>=0.63.3',
-  'pyproject-metadata>=0.6.1',
+  'pyproject-metadata>=0.7.0',
   'tomli>=1.0.0; python_version<"3.11"',
   'typing-extensions>=3.7.4; python_version<"3.10"',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = 'mesonpy'
 backend-path = ['.']
 requires = [
   'meson>=0.63.3',
-  'pyproject-metadata>=0.7.0',
+  'pyproject-metadata>=0.7.1',
   'tomli>=1.0.0; python_version<"3.11"',
   'typing-extensions>=3.7.4; python_version<"3.10"',
 ]


### PR DESCRIPTION
I updated the minimal version of `pyproject-metadata` because the versions < `0.7.0` have a bug on windows regarding the `utf-8` char decoding. 

I don't know if is it needed, because a a new installation already installs the `0.7.0` :man_shrugging: 