### PR TITLE
DOC: add live-reload to the nox docs session when serving

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -18,12 +18,14 @@ def docs(session):
 
     session.install('.[docs]')
     session.chdir('docs')
-    session.run('sphinx-build', '-M', 'html', '.', '_build')
 
-    if session.posargs:
+    sphinx_build_args = ('.', '_build')
+
+    if not session.posargs:
+        session.run('sphinx-build', '-M', 'html', *sphinx_build_args)
+    else:
         if 'serve' in session.posargs:
-            print('Launching docs at http://localhost:8000/ - use Ctrl-C to quit')
-            session.run('python', '-m', 'http.server', '8000', '-d', '_build/html')
+            session.run('sphinx-autobuild', *sphinx_build_args)
         else:
             print('Unsupported argument to docs')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ docs = [
   'furo>=2021.08.31',
   'sphinx~=4.0',
   'sphinx-autodoc-typehints>=1.10',
+  'sphinx-autobuild',
 ]
 
 [project.urls]


### PR DESCRIPTION
This uses sphinx-autobuild to spawn the http server, as it as live-reload support.

I found this useful when doing final touch-ups on documentation pages.

Signed-off-by: Filipe Laíns <lains@riseup.net>