### PR TITLE
BUG: fix creation of artifacts when the outdir does not exist

### DIFF
--- a/mesonpy/_util.py
+++ b/mesonpy/_util.py
@@ -46,6 +46,7 @@ def create_targz(path: Path) -> Iterator[Tuple[tarfile.TarFile, Optional[int]]]:
     source_date_epoch = os.environ.get('SOURCE_DATE_EPOCH')
     mtime = int(source_date_epoch) if source_date_epoch else None
 
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     file = typing.cast(IO[bytes], gzip.GzipFile(
         path,
         mode='wb',


### PR DESCRIPTION
PEP 517 does not specify whether sdist_directory or wheel_directory exist, and it may or may not do so.

Some projects that create it in advance, before calling our build_sdist and build_wheel hooks:
- pip
- pyproject-build
- gpep517

Some projects that do not create it:
- pdm

This may be a general problem in the ecosystem. Since nothing is specified, no one can assume anything -- the safest thing to do is have both the build backend and the build frontend create it, in order to ensure maximum compatibility between backends and frontends.

To make matters even more fun, pdm will delete the entire directory before invoking the build hooks. So even if you previously ran pyproject-build, pdm will delete the directory, then let meson-python fail because it doesn't exist.

Fixes https://github.com/mesonbuild/meson-python/discussions/273