### PR TITLE
MAINT: update isort to 5.12.0 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
 - repo: https://github.com/charliermarsh/ruff-pre-commit


### PR DESCRIPTION
Something seems to have broken in isort with the newest poetry release from I can tell. Anyway, update it to 5.12.0.