### PR TITLE
CI: use same line length limit for ruff and isort 

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -49,16 +49,11 @@ import mesonpy._tags
 import mesonpy._util
 import mesonpy._wheelfile
 
-from mesonpy._compat import (
-    Collection, Iterable, Mapping, cached_property, read_binary
-)
+from mesonpy._compat import Collection, Iterable, Mapping, cached_property, read_binary
 
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from typing import (
-        Any, Callable, ClassVar, DefaultDict, List, Optional, Sequence, Set,
-        TextIO, Tuple, Type, TypeVar, Union
-    )
+    from typing import Any, Callable, ClassVar, DefaultDict, List, Optional, Sequence, Set, TextIO, Tuple, Type, TypeVar, Union
 
     import pyproject_metadata
 

--- a/mesonpy/_compat.py
+++ b/mesonpy/_compat.py
@@ -15,9 +15,7 @@ import typing
 
 
 if sys.version_info >= (3, 9):
-    from collections.abc import (
-        Collection, Iterable, Iterator, Mapping, Sequence
-    )
+    from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 else:
     from typing import Collection, Iterable, Iterator, Mapping, Sequence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ lines_between_types = 1
 lines_after_imports = 2
 multi_line_output = 5
 known_first_party = 'mesonpy'
+line_length = 127
 
 
 [tool.coverage.run]


### PR DESCRIPTION
Having shorter lines for import statements enforced by isort started to give on my nerves...