### PR TITLE
BUG: improve validation of pyproject.toml meson-python configuration

### DIFF
--- a/tests/packages/unsupported-dynamic/meson.build
+++ b/tests/packages/unsupported-dynamic/meson.build
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+project('unsupported-dynamic', version: '1.0.0')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,11 +10,11 @@ def test_no_pep621(sdist_library):
     with tarfile.open(sdist_library, 'r:gz') as sdist:
         sdist_pkg_info = sdist.extractfile('library-1.0.0/PKG-INFO').read().decode()
 
-    assert sdist_pkg_info == textwrap.dedent('''
+    assert sdist_pkg_info == textwrap.dedent('''\
         Metadata-Version: 2.1
         Name: library
         Version: 1.0.0
-    ''').strip()
+    ''')
 
 
 def test_pep621(sdist_full_metadata):
@@ -61,10 +61,10 @@ def test_pep621(sdist_full_metadata):
 
 def test_dynamic_version(sdist_dynamic_version):
     with tarfile.open(sdist_dynamic_version, 'r:gz') as sdist:
-        sdist_pkg_info = sdist.extractfile('dynamic_version-1.0.0/PKG-INFO').read().decode().strip()
+        sdist_pkg_info = sdist.extractfile('dynamic_version-1.0.0/PKG-INFO').read().decode()
 
-    assert sdist_pkg_info == textwrap.dedent('''
+    assert sdist_pkg_info == textwrap.dedent('''\
         Metadata-Version: 2.1
         Name: dynamic-version
         Version: 1.0.0
-    ''').strip()
+    ''')

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -66,8 +66,7 @@ def test_invalid_config_settings(capsys, package_pure, tmp_path_session):
         with pytest.raises(SystemExit):
             method(tmp_path_session, {'invalid': ()})
         out, err = capsys.readouterr()
-        assert out.splitlines()[-1].endswith(
-            'Unknown configuration entry "invalid"')
+        assert out.splitlines()[-1].endswith('Unknown option "invalid"')
 
 
 def test_invalid_config_settings_suggest(capsys, package_pure, tmp_path_session):
@@ -75,5 +74,29 @@ def test_invalid_config_settings_suggest(capsys, package_pure, tmp_path_session)
         with pytest.raises(SystemExit):
             method(tmp_path_session, {'setup_args': ()})
         out, err = capsys.readouterr()
-        assert out.splitlines()[-1].endswith(
-            'Unknown configuration entry "setup_args". Did you mean "setup-args" or "dist-args"?')
+        assert out.splitlines()[-1].endswith('Unknown option "setup_args". Did you mean "setup-args" or "dist-args"?')
+
+
+def test_validate_config_settings_invalid():
+    with pytest.raises(mesonpy.ConfigError, match='Unknown option "invalid"'):
+        mesonpy._validate_config_settings({'invalid': ()})
+
+
+def test_validate_config_settings_repeated():
+    with pytest.raises(mesonpy.ConfigError, match='Only one value for "builddir" can be specified'):
+        mesonpy._validate_config_settings({'builddir': ['one', 'two']})
+
+
+def test_validate_config_settings_str():
+    config = mesonpy._validate_config_settings({'setup-args': '-Dfoo=true'})
+    assert config['setup-args'] == ['-Dfoo=true']
+
+
+def test_validate_config_settings_list():
+    config = mesonpy._validate_config_settings({'setup-args': ['-Done=1', '-Dtwo=2']})
+    assert config['setup-args'] == ['-Done=1', '-Dtwo=2']
+
+
+def test_validate_config_settings_tuple():
+    config = mesonpy._validate_config_settings({'setup-args': ('-Done=1', '-Dtwo=2')})
+    assert config['setup-args'] == ['-Done=1', '-Dtwo=2']


### PR DESCRIPTION
Switch from an incomplete (an bugged) ad hoc validation to a scheme based validation strategy. The scheme is defined in the function _validate_pyproject_config() as nested dictionaries where the keys are configuration field names and valued are validation functions. Unknown fields result in an error.

Fixes #293.