### PR TITLE
Rename MACOS_DEPLOYMENT_TARGET back to MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -48,7 +48,7 @@ Environment variables
           Please check our :ref:`how-to-guides-editable-installs` guide for more
           information on how to use it.
 
-   * - ``MACOS_DEPLOYMENT_TARGET``
+   * - ``MACOSX_DEPLOYMENT_TARGET``
      - Specify the target macOS version.
 
        If ``MACOSX_DEPLOYMENT_TARGET`` is set, we will use the selected version

--- a/mesonpy/_tags.py
+++ b/mesonpy/_tags.py
@@ -106,9 +106,9 @@ def _get_macosx_platform_tag() -> str:
         pass
 
     # Override the macOS version if one is provided via the
-    # MACOS_DEPLOYMENT_TARGET environment variable.
+    # MACOSX_DEPLOYMENT_TARGET environment variable.
     try:
-        version = tuple(map(int, os.environ.get('MACOS_DEPLOYMENT_TARGET', '').split('.')))[:2]
+        version = tuple(map(int, os.environ.get('MACOSX_DEPLOYMENT_TARGET', '').split('.')))[:2]
     except ValueError:
         version = tuple(map(int, ver.split('.')))[:2]
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -37,11 +37,11 @@ def test_wheel_tag():
 @pytest.mark.skipif(platform.system() != 'Darwin', reason='macOS specific test')
 def test_macos_platform_tag(monkeypatch):
     for minor in range(9, 16):
-        monkeypatch.setenv('MACOS_DEPLOYMENT_TARGET', f'10.{minor}')
+        monkeypatch.setenv('MACOSX_DEPLOYMENT_TARGET', f'10.{minor}')
         assert next(packaging.tags.mac_platforms((10, minor))) == mesonpy._tags.get_platform_tag()
     for major in range(11, 20):
         for minor in range(3):
-            monkeypatch.setenv('MACOS_DEPLOYMENT_TARGET', f'{major}.{minor}')
+            monkeypatch.setenv('MACOSX_DEPLOYMENT_TARGET', f'{major}.{minor}')
             assert next(packaging.tags.mac_platforms((major, minor))) == mesonpy._tags.get_platform_tag()
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -5,7 +5,6 @@
 import os
 import pathlib
 import platform
-import re
 import sysconfig
 
 from collections import defaultdict
@@ -93,18 +92,3 @@ def test_tag_mixed_abi(monkeypatch):
         'platlib': [f'extension{ABI3SUFFIX}', f'another{SUFFIX}'],
     })
     assert str(builder.tag) == f'{INTERPRETER}-{ABI}-{PLATFORM}'
-
-
-@pytest.mark.skipif(platform.system() != 'Darwin', reason='macOS specific test')
-def test_tag_macos_build_target(monkeypatch):
-    monkeypatch.setenv('MACOS_BUILD_TARGET', '12.0')
-    builder = wheel_builder_test_factory(monkeypatch, {
-        'platlib': [f'extension{SUFFIX}'],
-    })
-    assert builder.tag.platform == re.sub(r'\d+\.\d+', '12.0', PLATFORM)
-
-    monkeypatch.setenv('MACOS_BUILD_TARGET', '10.9')
-    builder = wheel_builder_test_factory(monkeypatch, {
-        'platlib': [f'extension{SUFFIX}'],
-    })
-    assert builder.tag.platform == re.sub(r'\d+\.\d+', '10.9', PLATFORM)


### PR DESCRIPTION
This is the environment variable name used by Apple (see compat(5)). It is also supported by cibuildwheel, CMAKE, etc.

It was renamed in 9e84bd993c359721c3011cddd7f2403e5b019f74

Closes https://github.com/pypa/cibuildwheel/issues/1419