### PR TITLE
CI: add job to build wheels and upload them when a release is tagged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+name: build
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: python -m pip install build twine
+      - run: python -m build
+      - run: if [[ "${{ github.ref }}" =~ [0-9]+\.[0-9]+\.[0-9]+(\..*)? ]]; then echo "UPLOAD=1" >> $GITHUB_ENV; fi
+      - run: python -m twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI }}
+        if: ${{ env.UPLOAD }}


### PR DESCRIPTION
I don't know if we want this. The main goal is to potentially distribute the duty of cutting releases and reduce the bus factor. We may not want to build the wheel and the sdist for pull requests, in that case the action triggers may be changed. The current choice is only to make sure that the action works properly.