### PR TITLE
ENH: do not check extension module file name against expected suffix

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -334,13 +334,9 @@ class _WheelBuilder():
                 match = re.match(r'^[^.]+(.*)$', path.name)
                 assert match is not None
                 suffix = match.group(1)
-                if suffix not in _EXTENSION_SUFFIXES:
-                    raise ValueError(
-                        f'Extension module {str(path)!r} not compatible with Python interpreter. '
-                        f'Filename suffix {suffix!r} not in {set(_EXTENSION_SUFFIXES)}.')
                 match = _EXTENSION_SUFFIX_REGEX.match(suffix)
-                assert match is not None
-                abis.append(match.group('abi'))
+                if match:
+                    abis.append(match.group('abi'))
 
         stable = [x for x in abis if x and re.match(r'abi\d+', x)]
         if len(stable) > 0 and len(stable) == len(abis) and all(x == stable[0] for x in stable[1:]):


### PR DESCRIPTION
Checking that the extensions modules filenames end with a suffix accepted by the current Python interpreter assumes that the wheel being assembled is for the same Python platform. This is not true when cross-compiling. The check protects against a very unlikely occurrence and makes life harder for tools that allow cross-compiling Python wheels. Remove it.

See #321.