### PR TITLE
ENH: set NDEBUG for release builds

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -811,6 +811,7 @@ class Project():
             f'--native-file={os.fspath(self._meson_native_file)}',
             # TODO: Allow configuring these arguments
             '-Ddebug=false',
+            '-Db_ndebug=if-release',
             '-Doptimization=2',
 
             # XXX: This should not be needed, but Meson is using the wrong paths


### PR DESCRIPTION
`NDEBUG` is normally expected to be set for release builds, however for historical reasons Meson does not (yet) toggle `NDEBUG` for non-debug builds (which we already default to). So set this as the default. Choosing 'if-release' so that if users are explicitly asking for a debug build via config-settings, they don't see a change in behavior.

xref https://github.com/numpy/numpy/issues/22546#issuecomment-1440771047