### PR TITLE
TST: depend on Cython 3.0b1 to fix tests build issue on Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
   'pytest-cov[toml]',
   'pytest-mock',
   'auditwheel',
-  'Cython',
+  'cython >= 3.0b1', # includes fix for https://github.com/cython/cython/issues/5238
   'wheel',
   'typing-extensions >= 3.7.4; python_version < "3.10"',
 ]


### PR DESCRIPTION
Use the normalized package name while at it.