### PR TITLE
ENH: format errors nicely on multiline error strings

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -1023,7 +1023,7 @@ def _pyproject_hook(func: Callable[P, T]) -> Callable[P, T]:
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         try:
             return func(*args, **kwargs)
-        except Error as exc:
+        except (Error, pyproject_metadata.ConfigurationError) as exc:
             print((
                 '{red}meson-python: error:{reset}\n'
                 '{red}>{reset}\n' +

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -1024,7 +1024,12 @@ def _pyproject_hook(func: Callable[P, T]) -> Callable[P, T]:
         try:
             return func(*args, **kwargs)
         except Error as exc:
-            print('{red}meson-python: error:{reset} {msg}'.format(msg=str(exc), **_STYLES))
+            print((
+                '{red}meson-python: error:{reset}\n'
+                '{red}>{reset}\n' +
+                textwrap.indent(str(exc).strip(), prefix='{red}>{reset}  ') + '\n' +
+                '{red}>{reset}\n'
+            ).format(**_STYLES))
             raise SystemExit(1) from exc
     return wrapper
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -1024,12 +1024,16 @@ def _pyproject_hook(func: Callable[P, T]) -> Callable[P, T]:
         try:
             return func(*args, **kwargs)
         except (Error, pyproject_metadata.ConfigurationError) as exc:
-            print((
-                '{red}meson-python: error:{reset}\n'
-                '{red}>{reset}\n' +
-                textwrap.indent(str(exc).strip(), prefix='{red}>{reset}  ') + '\n' +
-                '{red}>{reset}\n'
-            ).format(**_STYLES))
+            error_msg = '\n{red}meson-python: error:{reset}'
+            if '\n' in str(exc):
+                error_msg += (
+                    '{red}>{reset}\n' +
+                    textwrap.indent(str(exc).strip(), prefix='{red}>{reset}  ') + '\n' +
+                    '{red}>{reset}\n'
+                )
+            else:
+                error_msg += f' {exc}'
+            print(error_msg.format(**_STYLES))
             raise SystemExit(1) from exc
     return wrapper
 

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -66,7 +66,7 @@ def test_invalid_config_settings(capsys, package_pure, tmp_path_session):
         with pytest.raises(SystemExit):
             method(tmp_path_session, {'invalid': ()})
         out, err = capsys.readouterr()
-        assert out.splitlines()[-1].endswith('Unknown option "invalid"')
+        assert 'Unknown option "invalid"' in out
 
 
 def test_invalid_config_settings_suggest(capsys, package_pure, tmp_path_session):
@@ -74,7 +74,7 @@ def test_invalid_config_settings_suggest(capsys, package_pure, tmp_path_session)
         with pytest.raises(SystemExit):
             method(tmp_path_session, {'setup_args': ()})
         out, err = capsys.readouterr()
-        assert out.splitlines()[-1].endswith('Unknown option "setup_args". Did you mean "setup-args" or "dist-args"?')
+        assert 'Unknown option "setup_args". Did you mean "setup-args" or "dist-args"?' in out
 
 
 def test_validate_config_settings_invalid():


### PR DESCRIPTION
Before
```
meson-python: error: A single line error message
```
```
meson-python: error: A multiline error message. Eg. X went wrong in the fields:
- aaa
- bbb

And Y went wrong in:
- ccc
- ddd
```

After
```
meson-python: error: A single line error message
```
```
meson-python: error:
>
> A multiline error message. Eg. X went wrong in the fields:
> - aaa
> - bbb
> 
> And Y went wrong in:
> - ccc
> - ddd
> 
```

With the latest commit, I kept single-line error the same, following the review, keeping the change for multi-line errors only.

Note, the error messages get nicely colorized too. The `>` line prefix is red, and the following is reset text.