### PR TITLE
Handle ARCHFLAGS set to the empty string

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -686,8 +686,8 @@ class Project():
 
         # setuptools-like ARCHFLAGS environment variable support
         if sysconfig.get_platform().startswith('macosx-'):
-            archflags = self._env.get('ARCHFLAGS')
-            if archflags is not None:
+            archflags = self._env.get('ARCHFLAGS', '').strip()
+            if archflags:
                 arch, *other = filter(None, (x.strip() for x in archflags.split('-arch')))
                 if other:
                     raise ConfigError(f'Multi-architecture builds are not supported but $ARCHFLAGS={archflags!r}')


### PR DESCRIPTION
When `ARCHFLAGS` is set to the empty string, meson-python breaks; see https://github.com/sagemath/sage/pull/35082#issuecomment-1464890197
