### PR TITLE
MAINT: add stacklevel argument to warnings.warn

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -115,7 +115,10 @@ def _init_colors() -> Dict[str, str]:
     """
     if 'NO_COLOR' in os.environ:
         if 'FORCE_COLOR' in os.environ:
-            warnings.warn('Both NO_COLOR and FORCE_COLOR environment variables are set, disabling color')
+            warnings.warn(
+                'Both NO_COLOR and FORCE_COLOR environment variables are set, disabling color',
+                stacklevel=1,
+            )
         return _NO_COLORS
     elif 'FORCE_COLOR' in os.environ or sys.stdout.isatty():
         return _COLORS


### PR DESCRIPTION
This fixes B028.

> No explicit stacklevel keyword argument found. The warn method from the
> warnings module uses a stacklevel of 1 by default. This will only show a stack
> trace for the line on which the warn method is called. It is therefore
> recommended to use a stacklevel of 2 or greater to provide more information to
> the user.

I personally do not find this error very useful, but let's just pass the stacklevel argument and consider ignoring the error globally if we get more cases like this where this is the intended behavior.