### PR TITLE
TST: disable tests compiling Cython code on Python 3.12

### DIFF
--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -58,6 +58,7 @@ def test_collect(package_complex):
     assert tree['complex']['more']['__init__.py'] == os.path.join(root, 'complex', 'more', '__init__.py')
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Cython generated code does not compile on Python 3.12')
 def test_mesonpy_meta_finder(package_complex, tmp_build_path):
     # build a package in a temporary directory
     mesonpy.Project(package_complex, tmp_build_path)

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -51,6 +51,7 @@ def wheel_filename(artifact):
     return artifact.filename.split(os.sep)[-1]
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Cython generated code does not compile on Python 3.12')
 def test_scipy_like(wheel_scipy_like):
     # This test is meant to exercise features commonly needed by a regular
     # Python package for scientific computing or data science:


### PR DESCRIPTION
Cython generated code does not compile with Python 3.12. This cab be revisited once the next beta version of Cython 3.0 is released.

Fixes #337.