### PR TITLE
ENH: remove warning when package metadata generate from meson.build

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -721,10 +721,6 @@ class Project():
         else:
             self._metadata = pyproject_metadata.StandardMetadata(
                 name=self._meson_name, version=packaging.version.Version(self._meson_version))
-            print(
-                '{yellow}{bold}! Using Meson to generate the project metadata '
-                '(no `project` section in pyproject.toml){reset}'.format(**_STYLES)
-            )
         self._validate_metadata()
 
         # set version from meson.build if dynamic


### PR DESCRIPTION
This use case is supported and extensively used in the meson-python test suite, there is no reason to emit a warning when a supported feature is used. This is accordance with PEP 621, which states that the lack of a "project" table in pyproject.toml implicitly means that the build back-end will dynamically provide all fields.

Fixes #306.