### PR TITLE
DOC: amend copyright statement

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,7 @@ import mesonpy
 # -- Project information -----------------------------------------------------
 
 project = 'meson-python'
-copyright = '2021, Quansight Labs, Filipe Laíns'
-author = 'Filipe Laíns'
+copyright = '2021, The meson-python developers'
 
 # The short X.Y version
 version = mesonpy.__version__


### PR DESCRIPTION
Make the copyright statement shown in the documentation rendered pages consistent with the one declared in most documentation source files.