### PR TITLE
MAINT: Cython 3.0b2 solves compilation issues with Python 3.12a6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
   'pytest-cov[toml]',
   'pytest-mock',
   'auditwheel',
-  'cython >= 3.0b1', # includes fix for https://github.com/cython/cython/issues/5238
+  'cython >= 3.0b2', # includes fixes for compilation with Python 3.12
   'wheel',
   'typing-extensions >= 3.7.4; python_version < "3.10"',
 ]

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -58,7 +58,6 @@ def test_collect(package_complex):
     assert tree['complex']['more']['__init__.py'] == os.path.join(root, 'complex', 'more', '__init__.py')
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Cython generated code does not compile on Python 3.12')
 def test_mesonpy_meta_finder(package_complex, tmp_build_path):
     # build a package in a temporary directory
     mesonpy.Project(package_complex, tmp_build_path)

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -45,7 +45,6 @@ def wheel_contents(artifact):
     }
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Cython generated code does not compile on Python 3.12')
 def test_scipy_like(wheel_scipy_like):
     # This test is meant to exercise features commonly needed by a regular
     # Python package for scientific computing or data science:


### PR DESCRIPTION
Let's see if Cython 3.0b2 solves the compilation issues with Python 3.12a6