### PR TITLE
MAINT: add muon-fmt pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,8 @@ repos:
     pass_filenames: true
   - id: reuse
     name: reuse lint
+- repo: https://github.com/FFY00/muon-pre-commit
+  rev: 0.1.0-c6207ca1
+  hooks:
+  - id: muon-fmt
+    args: [-c, muon_fmt.ini]

--- a/docs/examples/spam/meson.build
+++ b/docs/examples/spam/meson.build
@@ -2,40 +2,28 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-  'spam',
-  'c',
-)
+project('spam', 'c')
 
 py_mod = import('python')
 py = py_mod.find_installation()
 
 # Specify directories to be included - usually this is where your header files live.
 # Note that specifying the path to Python.h is not necessary with meson-python.
-includes = include_directories(
-  [
-    'src'
-  ]
-)
+includes = include_directories(['src'])
 
 srcs = [
-  'src/spammodule.c',
+    'src/spammodule.c',
 ]
 
 # If some files (such as .py files) need to be copied to site-packages,
 # this is where they get specified. Files get copied to
 # <python directory>/site-packages/<subdir>
-py.install_sources(
-  [
-    'src/__init__.py'
-  ],
-  subdir: 'spam'
-)
+py.install_sources(['src/__init__.py'], subdir: 'spam')
 
 py.extension_module(
-  '_spam',
-  srcs,
-  install: true,
-  subdir: 'spam',
-  include_directories: includes
+    '_spam',
+    srcs,
+    install: true,
+    subdir: 'spam',
+    include_directories: includes,
 )

--- a/meson.build
+++ b/meson.build
@@ -8,18 +8,18 @@ py_mod = import('python')
 py = py_mod.find_installation()
 
 if py.language_version().version_compare('< 3.6')
-  error('Invalid Python version, only >= 3.6 is supported.')
+    error('Invalid Python version, only >= 3.6 is supported.')
 endif
 
 py.install_sources(
-  'mesonpy/__init__.py',
-  'mesonpy/_compat.py',
-  'mesonpy/_dylib.py',
-  'mesonpy/_editable.py',
-  'mesonpy/_elf.py',
-  'mesonpy/_introspection.py',
-  'mesonpy/_tags.py',
-  'mesonpy/_util.py',
-  'mesonpy/_wheelfile.py',
-  subdir: 'mesonpy',
+    'mesonpy/__init__.py',
+    'mesonpy/_compat.py',
+    'mesonpy/_dylib.py',
+    'mesonpy/_editable.py',
+    'mesonpy/_elf.py',
+    'mesonpy/_introspection.py',
+    'mesonpy/_tags.py',
+    'mesonpy/_util.py',
+    'mesonpy/_wheelfile.py',
+    subdir: 'mesonpy',
 )

--- a/muon_fmt.ini
+++ b/muon_fmt.ini
@@ -1,0 +1,5 @@
+; SPDX-FileCopyrightText: 2023 The meson-python developers
+;
+; SPDX-License-Identifier: MIT
+
+max_line_len = 127

--- a/tests/packages/complex/meson.build
+++ b/tests/packages/complex/meson.build
@@ -5,7 +5,7 @@
 project('complex', 'c', 'cython', version: '1.0.0')
 
 if host_machine.system() == 'windows' and meson.get_compiler('c').get_id() == 'gcc'
-  add_project_arguments('-DMS_WIN64', language: ['c', 'cpp'])
+    add_project_arguments('-DMS_WIN64', language: ['c', 'cpp'])
 endif
 
 py = import('python').find_installation()

--- a/tests/packages/configure-data/meson.build
+++ b/tests/packages/configure-data/meson.build
@@ -13,8 +13,6 @@ py = py_mod.find_installation()
 configure_file(
     input: 'configure_data.py.in',
     output: 'configure_data.py',
-    configuration: configuration_data({
-        'MSG': 'hello!',
-    }),
+    configuration: configuration_data({'MSG': 'hello!'}),
     install_dir: py.get_install_dir(),
 )

--- a/tests/packages/dist-script/meson.build
+++ b/tests/packages/dist-script/meson.build
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'dist-script', 'c',
-    version: '1.0.0',
-)
+project('dist-script', 'c', version: '1.0.0')
 
 meson.add_dist_script('')

--- a/tests/packages/executable-bit/meson.build
+++ b/tests/packages/executable-bit/meson.build
@@ -2,16 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'executable-bit', 'c',
-    version: '1.0.0',
-)
+project('executable-bit', 'c', version: '1.0.0')
 
 py_mod = import('python')
 py = py_mod.find_installation()
 
 executable(
-    'example', 'example.c',
+    'example',
+    'example.c',
     install: true,
 )
 

--- a/tests/packages/executable/meson.build
+++ b/tests/packages/executable/meson.build
@@ -2,12 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'executable', 'c',
-    version: '1.0.0',
-)
+project('executable', 'c', version: '1.0.0')
 
 executable(
-    'example', 'example.c',
+    'example',
+    'example.c',
     install: true,
 )

--- a/tests/packages/generated-files/meson.build
+++ b/tests/packages/generated-files/meson.build
@@ -2,17 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'executable-bit', 'c',
-    version: '1.0.0',
-)
+project('executable-bit', 'c', version: '1.0.0')
 
 py_mod = import('python')
 fs = import('fs')
 py = py_mod.find_installation()
 
 executable(
-    'example', 'example.c',
+    'example',
+    'example.c',
     install: true,
 )
 
@@ -29,15 +27,14 @@ version_gen = files('generate_version.py')
 if fs.exists('_version_meson.py')
     py.install_sources('_version_meson.py')
 else
-    custom_target('write_version_file',
+    custom_target(
+        'write_version_file',
         output: '_version_meson.py',
-        command: [
-            py, version_gen, '-o', '@OUTPUT@'
-        ],
+        command: [py, version_gen, '-o', '@OUTPUT@'],
         build_by_default: true,
         build_always_stale: true,
         install: true,
-        install_dir: py.get_install_dir(pure: false)
+        install_dir: py.get_install_dir(pure: false),
     )
     meson.add_dist_script(py, version_gen, '-o', '_version_meson.py')
 endif

--- a/tests/packages/imports-itself-during-build/meson.build
+++ b/tests/packages/imports-itself-during-build/meson.build
@@ -2,17 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'imports-itself-during-build', 'c',
-    version: '1.0.0',
-)
+project('imports-itself-during-build', 'c', version: '1.0.0')
 
 py_mod = import('python')
 py = py_mod.find_installation()
 
 py.install_sources('pure.py')
 py.extension_module(
-    'plat', 'plat.c',
+    'plat',
+    'plat.c',
     install: true,
 )
 

--- a/tests/packages/library-pep621/meson.build
+++ b/tests/packages/library-pep621/meson.build
@@ -5,12 +5,14 @@
 project('library-pep621', 'c')
 
 example_lib = shared_library(
-    'example', 'examplelib.c',
+    'example',
+    'examplelib.c',
     install: true,
 )
 
 executable(
-    'example', 'example.c',
+    'example',
+    'example.c',
     link_with: example_lib,
     install: true,
 )

--- a/tests/packages/library/meson.build
+++ b/tests/packages/library/meson.build
@@ -2,20 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'library', 'c',
-    version: '1.0.0',
-)
+project('library', 'c', version: '1.0.0')
 
 install_headers('examplelib.h')
 
 example_lib = shared_library(
-    'example', 'examplelib.c',
+    'example',
+    'examplelib.c',
     install: true,
 )
 
 executable(
-    'example', 'example.c',
+    'example',
+    'example.c',
     link_with: example_lib,
     install: true,
 )

--- a/tests/packages/link-against-local-lib/meson.build
+++ b/tests/packages/link-against-local-lib/meson.build
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'link-against-local-lib', 'c',
-    version: '1.0.0',
-)
+project('link-against-local-lib', 'c', version: '1.0.0')
 
 example_lib = shared_library(
-    'example', 'examplelib.c',
+    'example',
+    'examplelib.c',
     install: true,
 )
 
@@ -16,7 +14,8 @@ py_mod = import('python')
 py = py_mod.find_installation()
 
 py.extension_module(
-    'example', 'examplemod.c',
+    'example',
+    'examplemod.c',
     link_with: example_lib,
     install: true,
 )

--- a/tests/packages/module-types/meson.build
+++ b/tests/packages/module-types/meson.build
@@ -2,10 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'module-types', 'c',
-    version: '1.0.0',
-)
+project('module-types', 'c', version: '1.0.0')
 
 py_mod = import('python')
 py = py_mod.find_installation()
@@ -20,6 +17,7 @@ py.install_sources(
     subdir: 'namespace',
 )
 py.extension_module(
-    'native', 'native.c',
+    'native',
+    'native.c',
     install: true,
 )

--- a/tests/packages/purelib-and-platlib/meson.build
+++ b/tests/packages/purelib-and-platlib/meson.build
@@ -2,16 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-project(
-    'purelib-and-platlib', 'c',
-    version: '1.0.0',
-)
+project('purelib-and-platlib', 'c', version: '1.0.0')
 
 py_mod = import('python')
 py = py_mod.find_installation()
 
 py.install_sources('pure.py')
 py.extension_module(
-    'plat', 'plat.c',
+    'plat',
+    'plat.c',
     install: true,
 )

--- a/tests/packages/scipy-like/meson.build
+++ b/tests/packages/scipy-like/meson.build
@@ -2,10 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-project('scipy-like',
-  'c', 'cython',
-  version: '2.3.4',
-)
+project('scipy-like', 'c', 'cython', version: '2.3.4')
 
 py_mod = import('python')
 py = py_mod.find_installation()
@@ -14,10 +11,10 @@ cc = meson.get_compiler('c')
 is_windows = host_machine.system() == 'windows'
 is_mingw = is_windows and cc.get_id() == 'gcc'
 if is_mingw
-  # We may be using Mingw in CI, and Cython needs this define when using Mingw
-  # together with a MSVC-built Python, see
-  # https://github.com/cython/cython/issues/3405
-  add_project_arguments('-DMS_WIN64', language: ['c', 'cpp'])
+    # We may be using Mingw in CI, and Cython needs this define when using Mingw
+    # together with a MSVC-built Python, see
+    # https://github.com/cython/cython/issues/3405
+    add_project_arguments('-DMS_WIN64', language: ['c', 'cpp'])
 endif
 
 subdir('mypkg')

--- a/tests/packages/scipy-like/mypkg/meson.build
+++ b/tests/packages/scipy-like/mypkg/meson.build
@@ -2,36 +2,22 @@
 #
 # SPDX-License-Identifier: MIT
 
-generate_version = custom_target('generate-config-file',
-  install: true,
-  build_always_stale: true,
-  build_by_default: true,
-  output: '__config__.py',
-  input: '../tools/generate_config.py',
-  command: [py, '@INPUT@', '@OUTPUT@'],
-  install_dir: py.get_install_dir(pure: false) / 'mypkg'
+generate_version = custom_target(
+    'generate-config-file',
+    install: true,
+    build_always_stale: true,
+    build_by_default: true,
+    output: '__config__.py',
+    input: '../tools/generate_config.py',
+    command: [py, '@INPUT@', '@OUTPUT@'],
+    install_dir: py.get_install_dir(pure: false) / 'mypkg',
 )
 
-py.extension_module('extmod',
-  'extmod.c',
-  install: true,
-  subdir: 'mypkg'
-)
+py.extension_module('extmod', 'extmod.c', install: true, subdir: 'mypkg')
 
-py.extension_module('cy_extmod',
-  'cy_extmod.pyx',
-  install: true,
-  subdir: 'mypkg'
-)
+py.extension_module('cy_extmod', 'cy_extmod.pyx', install: true, subdir: 'mypkg')
 
-py.install_sources(
-  '__init__.py',
-  pure: false,
-  subdir: 'mypkg'
-)
+py.install_sources('__init__.py', pure: false, subdir: 'mypkg')
 
 # Still broken, see gh-105 and https://github.com/mesonbuild/meson/issues/10639
-install_subdir(
-  'submod',
-  install_dir: py.get_install_dir(pure: false) / 'mypkg'
-)
+install_subdir('submod', install_dir: py.get_install_dir(pure: false) / 'mypkg')

--- a/tests/packages/simple/meson.build
+++ b/tests/packages/simple/meson.build
@@ -6,8 +6,4 @@ project('simple', version: '1.0.0')
 
 py = import('python').find_installation()
 
-py.install_sources(
-  '__init__.py',
-  'test.py',
-  'data.txt',
-  subdir: 'simple')
+py.install_sources('__init__.py', 'test.py', 'data.txt', subdir: 'simple')

--- a/tests/packages/subdirs/meson.build
+++ b/tests/packages/subdirs/meson.build
@@ -8,15 +8,7 @@ py = import('python').find_installation()
 
 # in Meson >= 0.64 this could be replace with a single
 # py.install_sources() with the 'preserve_path: true' argument.
-py.install_sources(
-  'subdirs/__init__.py',
-  subdir: 'subdirs')
-py.install_sources(
-  'subdirs/a/__init__.py',
-  subdir: 'subdirs/a')
-py.install_sources(
-  'subdirs/a/b/c.py',
-  subdir: 'subdirs/a/b')
-py.install_sources(
-  'subdirs/b/c.py',
-  subdir: 'subdirs/b')
+py.install_sources('subdirs/__init__.py', subdir: 'subdirs')
+py.install_sources('subdirs/a/__init__.py', subdir: 'subdirs/a')
+py.install_sources('subdirs/a/b/c.py', subdir: 'subdirs/a/b')
+py.install_sources('subdirs/b/c.py', subdir: 'subdirs/b')


### PR DESCRIPTION
Similarly to #347, it'd also be good to have an autoformatter for the meson files, to ensure we have a consistent style.

The only worry is that muon currently only supports Meson 0.64.0, which will limit us to that syntax, but I don't think we need any fancy features anyway, so I am not worried about that.