### PR TITLE
BUG: Use meson compile wrapper on Windows

### DIFF
--- a/docs/how-to-guides/meson-args.rst
+++ b/docs/how-to-guides/meson-args.rst
@@ -44,6 +44,20 @@ building a Python wheel. User options specified via ``pyproject.toml``
 or via Python build front-end config settings override the
 ``meson-python`` defaults.
 
+When building on Windows, ``meson-python`` invokes the ``ninja``
+command via the ``meson compile`` wrapper. When the GCC or the LLVM
+compilers are not found on the ``$PATH``, this activates the Visual
+Studio environment and allows ``ninja`` to use the MSVC compilers. To
+activate the Visual Studio environment unconditionally, pass the
+``--vsenv`` option to ``meson setup``, see this :ref:`example
+<vsenv-example>`. When using the ``meson compile`` wrapper, the user
+supplied options for the compilation command are passed via the
+``--ninja-args`` option. This ensures that the behaviour is
+independent of how the build is initiated. Refer to the `Meson
+documentation`__ for more details.
+
+__ https://mesonbuild.com/Commands.html#backend-specific-arguments
+
 
 Examples
 ========
@@ -152,3 +166,44 @@ To set this option temporarily at build-time:
         .. code-block:: console
 
 	   $ python -m pip wheel . --config-settings=setup-args="-Doptimization=3" .
+
+
+.. _vsenv-example:
+
+Force the use of the MSVC compilers on Windows
+----------------------------------------------
+
+The MSVC compilers are not installed in the ``$PATH``. The Visual
+Studio environment needs to be activated for ``ninja`` to be able to
+use these compilers. This is taken care of by ``meson compile`` but
+only when the GCC compilers or the LLVM compilers are not found on the
+``$PATH``. Passing the ``--vsenv`` option to ``meson setup`` forces
+the activation of the Visual Studio environment and generates an error
+when the activation fails.
+
+This option has no effect on other platforms thus, if your project
+requires to be compiled with MSVC, you can consider to set this option
+permanently in the project's ``pyproject.toml``:
+
+.. code-block:: toml
+
+   [tool.meson-python.args]
+   setup = ['--vsenv']
+
+To set this option temporarily at build-time:
+
+.. tab-set::
+
+    .. tab-item:: pypa/build
+        :sync: key_pypa_build
+
+        .. code-block:: console
+
+	   $ python -m build -Csetup-args="--vsenv" .
+
+    .. tab-item:: pip
+        :sync: key_pip
+
+        .. code-block:: console
+
+	   $ python -m pip wheel . --config-settings=setup-args="--vsenv" .

--- a/tests/packages/detect-compiler/detect_compiler.c
+++ b/tests/packages/detect-compiler/detect_compiler.c
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 The meson-python developers
+//
+// SPDX-License-Identifier: MIT
+
+#include <Python.h>
+
+#if defined _MSC_VER
+#  define _COMPILER "msvc"
+#elif defined __clang__
+#  define _COMPILER "clang"
+#elif defined __GNUC__
+#  define _COMPILER "gcc"
+#else
+#  define _COMPILER "unknown"
+#endif
+
+static PyObject* compiler(PyObject* self)
+{
+    return PyUnicode_FromString(_COMPILER);
+}
+
+static PyMethodDef methods[] = {
+    {"compiler", (PyCFunction)compiler, METH_NOARGS, NULL},
+    {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "detect_compiler",
+    NULL,
+    -1,
+    methods,
+};
+
+PyMODINIT_FUNC PyInit_detect_compiler(void)
+{
+    return PyModule_Create(&module);
+}

--- a/tests/packages/detect-compiler/meson.build
+++ b/tests/packages/detect-compiler/meson.build
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+project(
+    'detect-compiler',
+    'c',
+    version: '1.0',
+)
+
+py = import('python').find_installation()
+
+py.extension_module('detect_compiler', 'detect_compiler.c', install: true)

--- a/tests/packages/detect-compiler/pyproject.toml
+++ b/tests/packages/detect-compiler/pyproject.toml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']


### PR DESCRIPTION
Necessary if e.g. the user passes requests vsenv from meson setup.
(I guess I could restrict this to only when vsenv is requested in setup, but this needs thought as to how it would work with existing builddirs. I don't remember OTOH if we reconfigure the build dir if it exists already).

With this, pandas should be getting close to greenish again.

I still need to add a test for this, but this should be the right idea.