### PR TITLE
TST: add test demonstrating the ndebug issue

### DIFF
--- a/tests/test_default_options.py
+++ b/tests/test_default_options.py
@@ -1,0 +1,15 @@
+import os
+import subprocess
+
+import pytest
+
+import mesonpy
+
+
+@pytest.mark.parametrize('args', [[], ['-Dbuildtype=release']], ids=['defaults', '-Dbuildtype=release'])
+def test_ndebug(package_scipy_like, tmp_path, args):
+    with mesonpy._project({'setup-args': args}) as project:
+        command = subprocess.run(
+            ['ninja', '-C', os.fspath(project._build_dir), '-t', 'commands', '../../mypkg/extmod.c^'],
+            stdout=subprocess.PIPE, check=True).stdout
+        assert b'-DNDEBUG' in command


### PR DESCRIPTION
The meson-python `-Db_ndebug=if-release` default option does not have effect unless the project is also configured with `-Dbuildtype=release` or `default_options: ['buildtype=release']` is specified in `project()`. I believe this was not the desired effect.