### PR TITLE
ENH: specify meson-python native file as last option to meson setup

### DIFF
--- a/docs/explanations/default-options.rst
+++ b/docs/explanations/default-options.rst
@@ -50,9 +50,10 @@ The options that ``meson-python`` specifies by default are:
 
    Additional ``--native-file`` options can be passed to ``meson
    setup`` if further adjustments to the native environment need to be
-   made. Meson will merge the contents of all machine files. The
-   user-provided machine files must not override the path for the
-   ``python`` binary.
+   made. Meson will merge the contents of all machine files. To ensure
+   everything works as expected, the ``meson-python`` native file is
+   last in the command line, overriding the ``python`` binary path
+   that may have been specified in user supplied native files.
 
 .. option:: buildtype=release
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -740,13 +740,16 @@ class Project():
         setup_args = [
             os.fspath(self._source_dir),
             os.fspath(self._build_dir),
-            f'--native-file={os.fspath(self._meson_native_file)}',
             # default build options
             '-Dbuildtype=release',
             '-Db_ndebug=if-release',
             '-Db_vscrt=md',
             # user build options
             *self._meson_args['setup'],
+            # pass native file last to have it override the python
+            # interpreter path that may have been specified in user
+            # provided native files
+            f'--native-file={os.fspath(self._meson_native_file)}',
         ]
         if reconfigure:
             setup_args.insert(0, '--reconfigure')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -69,9 +69,6 @@ def test_user_args(package_user_args, tmp_path, monkeypatch):
 
     monkeypatch.setattr(mesonpy.Project, '_run', wrapper)
 
-    def last_two_meson_args():
-        return [args[-2:] for args in call_args_list]
-
     config_settings = {
         'dist-args': ('cli-dist',),
         'setup-args': ('cli-setup',),
@@ -82,7 +79,7 @@ def test_user_args(package_user_args, tmp_path, monkeypatch):
     mesonpy.build_sdist(tmp_path, config_settings)
     mesonpy.build_wheel(tmp_path, config_settings)
 
-    assert last_two_meson_args() == [
+    expected = [
         # sdist: calls to 'meson setup' and 'meson dist'
         ('config-setup', 'cli-setup'),
         ('config-dist', 'cli-dist'),
@@ -91,6 +88,10 @@ def test_user_args(package_user_args, tmp_path, monkeypatch):
         ('config-compile', 'cli-compile'),
         ('config-install', 'cli-install'),
     ]
+
+    for expected_args, call_args in zip(expected, call_args_list):
+        for arg in expected_args:
+            assert arg in call_args
 
 
 @pytest.mark.parametrize('package', ('top-level', 'meson-args'))


### PR DESCRIPTION
This ensure that the python interpreter path specified in the meson-python native file overrides any other provided in user supplied native files.

Fixes #330.