### PR TITLE
CI: make ruff show the lint violations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
   rev: v0.0.261
   hooks:
   - id: ruff
-    args: [--fix, --show-fixes, --format, grouped]
 - repo: https://github.com/fsfe/reuse-tool
   rev: v1.1.2
   hooks:


### PR DESCRIPTION
I admit that I don't understand why we disable automatic fixup but then configure the linters to apply fixes. I'm going to leave this here till someone proposes an explanation.