### PR TITLE
BUG: fix system name specified when cross compiling via $ARCHFLAGS

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -678,7 +678,7 @@ class Project():
                         c = ['cc', '-arch', {arch!r}]
                         cpp = ['c++', '-arch', {arch!r}]
                         [host_machine]
-                        system = 'Darwin'
+                        system = 'darwin'
                         cpu = {arch!r}
                         cpu_family = {family!r}
                         endian = 'little'


### PR DESCRIPTION
Fixes #426.