### PR TITLE
ENH: implement --skip-subprojects install option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,10 @@ jobs:
           - os: ubuntu
             python: '3.11'
             meson: '~=1.0.0'
+          # Test with Meson master branch.
+          - os: ubuntu
+            python: '3.11'
+            meson: '@git+https://github.com/mesonbuild/meson.git'
 
     steps:
       - name: Checkout

--- a/tests/packages/subproject/meson.build
+++ b/tests/packages/subproject/meson.build
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+project('subproject', version: '1.0.0')
+
+subproject('dep')
+
+py = import('python').find_installation()
+
+py.install_sources('subproject.py')

--- a/tests/packages/subproject/pyproject.toml
+++ b/tests/packages/subproject/pyproject.toml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']

--- a/tests/packages/subproject/subproject.py
+++ b/tests/packages/subproject/subproject.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT

--- a/tests/packages/subproject/subprojects/dep/dep.py
+++ b/tests/packages/subproject/subprojects/dep/dep.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT

--- a/tests/packages/subproject/subprojects/dep/meson.build
+++ b/tests/packages/subproject/subprojects/dep/meson.build
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+project('dep')
+
+py = import('python').find_installation()
+
+py.install_sources('dep.py')


### PR DESCRIPTION
Requires introspection metadata added in upcoming Meson release 1.2.0.

Fixes #423.