### PR TITLE
CI: replace Python 3.7 with Python 3.8 on Homebrew

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -282,7 +282,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '3.7'
+          - '3.8'
           - '3.11'
         meson:
           -


### PR DESCRIPTION
Homebrew dropped support for Python 3.7.