### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   rev: 5.12.0
   hooks:
   - id: isort
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.0.261
   hooks:
   - id: ruff


### PR DESCRIPTION
See scientific-python/cookie#200.
