### PR TITLE
ci: Update test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,9 @@ jobs:
           - os: ubuntu
             python: '3.11'
             meson: '~=1.0.0'
+          - os: ubuntu
+            python: '3.11'
+            meson: '~=1.1.0'
           # Test with Meson master branch.
           - os: ubuntu
             python: '3.11'


### PR DESCRIPTION
Meson 1.2 has been released and is the new baseline version for running the test suite. Add Meson 1.1 to the list of older Meson versions we test against.