### PR TITLE
BUG: fix handling of missing 'version' metadata field version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -348,6 +348,9 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Install dependencies
+        run: python -m pip install .
+
       - name: Install mypy
         run: python -m pip --disable-pip-version-check install mypy==1.5.1
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -734,10 +734,18 @@ class Project():
             self._metadata = Metadata.from_pyproject(pyproject, self._source_dir)
             # set version from meson.build if version is declared as dynamic
             if 'version' in self._metadata.dynamic:
-                self._metadata.version = packaging.version.Version(self._meson_version)
+                version = self._meson_version
+                if version == 'undefined':
+                    raise pyproject_metadata.ConfigurationError(
+                        'Field "version" declared as dynamic but version is not defined in meson.build')
+                self._metadata.version = packaging.version.Version(version)
         else:
             # if project section is missing, use minimal metdata from meson.build
-            self._metadata = Metadata(name=self._meson_name, version=packaging.version.Version(self._meson_version))
+            name, version = self._meson_name, self._meson_version
+            if version == 'undefined':
+                raise pyproject_metadata.ConfigurationError(
+                    'Section "project" missing in pyproject.toml and version is not defined in meson.build')
+            self._metadata = Metadata(name=name, version=packaging.version.Version(version))
 
         # verify that we are running on a supported interpreter
         if self._metadata.requires_python:

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -252,7 +252,7 @@ class _WheelBuilder():
     def __init__(
         self,
         project: Project,
-        metadata: Optional[Metadata],
+        metadata: Metadata,
         source_dir: pathlib.Path,
         build_dir: pathlib.Path,
         sources: Dict[str, Dict[str, Any]],
@@ -349,9 +349,6 @@ class _WheelBuilder():
     @property
     def entrypoints_txt(self) -> bytes:
         """dist-info entry_points.txt."""
-        if not self._metadata:
-            return b''
-
         data = self._metadata.entrypoints.copy()
         data.update({
             'console_scripts': self._metadata.scripts,
@@ -902,10 +899,9 @@ class Project():
 
     @property
     def license_file(self) -> Optional[pathlib.Path]:
-        if self._metadata:
-            license_ = self._metadata.license
-            if license_ and license_.file:
-                return pathlib.Path(license_.file)
+        license_ = self._metadata.license
+        if license_ and license_.file:
+            return pathlib.Path(license_.file)
         return None
 
     @property

--- a/tests/packages/missing-dynamic-version/meson.build
+++ b/tests/packages/missing-dynamic-version/meson.build
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+project('missing-dynamic-version')

--- a/tests/packages/missing-dynamic-version/pyproject.toml
+++ b/tests/packages/missing-dynamic-version/pyproject.toml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']
+
+[project]
+name = 'missing-dynamic-version'
+dynamic = ['version']

--- a/tests/packages/missing-meson-version/meson.build
+++ b/tests/packages/missing-meson-version/meson.build
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+project('missing-meson-version')

--- a/tests/packages/missing-meson-version/pyproject.toml
+++ b/tests/packages/missing-meson-version/pyproject.toml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']

--- a/tests/packages/missing-version/meson.build
+++ b/tests/packages/missing-version/meson.build
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+project('missing-version', version: '1.0.0')

--- a/tests/packages/missing-version/pyproject.toml
+++ b/tests/packages/missing-version/pyproject.toml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']
+
+[project]
+name = 'missing-version'

--- a/tests/packages/scipy-like/pyproject.toml
+++ b/tests/packages/scipy-like/pyproject.toml
@@ -9,3 +9,4 @@ requires = ['meson-python']
 [project]
 name = "mypkg"
 description = "A typical Python package layout"
+dynamic = ['version']

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -48,15 +48,13 @@ def test_version(package):
 
 
 def test_unsupported_dynamic(package_unsupported_dynamic):
-    with pytest.raises(mesonpy.MesonBuilderError, match='Unsupported dynamic fields: "dependencies"'):
+    with pytest.raises(pyproject_metadata.ConfigurationError, match='Unsupported dynamic fields: "dependencies"'):
         with mesonpy.Project.with_temp_working_dir():
             pass
 
 
 def test_unsupported_python_version(package_unsupported_python_version):
-    with pytest.raises(mesonpy.MesonBuilderError, match=(
-        f'Unsupported Python version {platform.python_version()}, expected ==1.0.0'
-    )):
+    with pytest.raises(mesonpy.MesonBuilderError, match='Package requires Python version ==1.0.0'):
         with mesonpy.Project.with_temp_working_dir():
             pass
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -15,6 +15,7 @@ if sys.version_info < (3, 11):
 else:
     import tomllib
 
+import pyproject_metadata
 import pytest
 
 import mesonpy
@@ -59,6 +60,11 @@ def test_unsupported_python_version(package_unsupported_python_version):
         with mesonpy.Project.with_temp_working_dir():
             pass
 
+
+def test_missing_version(package_missing_version):
+    with pytest.raises(pyproject_metadata.ConfigurationError, match='Required "project.version" field is missing'):
+        with mesonpy.Project.with_temp_working_dir():
+            pass
 
 def test_user_args(package_user_args, tmp_path, monkeypatch):
     project_run = mesonpy.Project._run

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -64,6 +64,19 @@ def test_missing_version(package_missing_version):
         with mesonpy.Project.with_temp_working_dir():
             pass
 
+
+def test_missing_meson_version(package_missing_meson_version):
+    with pytest.raises(pyproject_metadata.ConfigurationError, match='Section "project" missing in pyproject.toml'):
+        with mesonpy.Project.with_temp_working_dir():
+            pass
+
+
+def test_missing_dynamic_version(package_missing_dynamic_version):
+    with pytest.raises(pyproject_metadata.ConfigurationError, match='Field "version" declared as dynamic but'):
+        with mesonpy.Project.with_temp_working_dir():
+            pass
+
+
 def test_user_args(package_user_args, tmp_path, monkeypatch):
     project_run = mesonpy.Project._run
     cmds = []


### PR DESCRIPTION
This locally fixes a bug in pyproject-metadata.

Fixes https://github.com/mesonbuild/meson-python/issues/454.