### PR TITLE
ENH: add objc and objcpp to the $ARCHFLAGS generated cross file

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -681,6 +681,8 @@ class Project():
                         [binaries]
                         c = ['cc', '-arch', {arch!r}]
                         cpp = ['c++', '-arch', {arch!r}]
+                        objc = ['cc', '-arch', {arch!r}]
+                        objcpp = ['c++', '-arch', {arch!r}]
                         [host_machine]
                         system = 'darwin'
                         cpu = {arch!r}


### PR DESCRIPTION
Allows $ARCHFLAGS enabled cross compilation of objc and objcpp.

Fixes #468.