### PR TITLE
Fix editable install of meson-python for pip 23.2.1 and python3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,9 @@ jobs:
         python:
           - '3.7'
           - '3.11'
+        editable:
+          - true
+          - false
         meson:
           -
         include:
@@ -75,7 +78,6 @@ jobs:
           - os: windows
             python: '3.11'
             meson: '@git+https://github.com/mesonbuild/meson.git'
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -103,6 +105,11 @@ jobs:
 
       - name: Install
         run: python -m pip --disable-pip-version-check install .[test]
+        if: ${{ ! matrix.editable }}
+
+      - name: Editable Install
+        run: python -m pip --disable-pip-version-check install -e .[test]
+        if: ${{ matrix.editable }}
 
       - name: Run tests
         run: >-
@@ -111,6 +118,8 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
         if: ${{ always() }}
+
+
 
   msvc:
     runs-on: windows-latest

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -1099,3 +1099,25 @@ def get_requires_for_build_editable(
     config_settings: Optional[Dict[str, str]] = None,
 ) -> List[str]:
     return get_requires_for_build_wheel()
+
+@_pyproject_hook
+def prepare_metadata_for_build_editable(
+    metadata_directory: str,
+    config_settings: Optional[Dict[str, str]] = None,
+) -> str:
+
+    with _project(config_settings) as project:
+        wheelbuilder = project._wheel_builder
+
+        dist_info_dir = pathlib.Path(metadata_directory, f'{wheelbuilder.basename}.dist-info')
+        dist_info_dir.mkdir(parents=True, exist_ok=True)
+
+        with dist_info_dir.joinpath('METADATA').open(mode='ab') as f:
+            f.write(project.metadata)
+        with dist_info_dir.joinpath('WHEEL').open(mode='ab') as f:
+            f.write(wheelbuilder.wheel)
+
+        if wheelbuilder.entrypoints_txt:
+            with dist_info_dir.joinpath('entry_points.txt').open(mode='ab') as f:
+                f.write(wheelbuilder.entrypoints_txt)
+        return str(dist_info_dir)

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -39,7 +39,20 @@ else:
     class Traversable:
         pass
     class TraversableResources:
-        pass
+        def files(self):
+            pass
+
+        def open_resource(self, resource):
+            return self.files().joinpath(resource).open('rb')
+
+        def resource_path(self, resource):
+            raise FileNotFoundError(resource)
+
+        def is_resource(self, path):
+            return self.files().joinpath(path).is_file()
+
+        def contents(self):
+            return (item.name for item in self.files().iterdir())
 
 
 MARKER = 'MESONPY_EDITABLE_SKIP'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,7 +165,7 @@ def pep518_wheelhouse(tmp_path_factory):
     packages = [
         meson_python,
     ]
-    cmd = [sys.executable, '-m', 'pip', 'wheel', '--no-build-isolation', '--wheel-dir', wheelhouse, *packages]
+    cmd = [sys.executable, '-m', 'pip', 'wheel',  '--wheel-dir', wheelhouse, *packages]
     subprocess.run(cmd, check=True)
     return wheelhouse
 


### PR DESCRIPTION
With python 3.11 and pip 23.2.1, an editable install of meson-python itself fails with:
`pip._internal.exceptions.InstallationSubprocessError: Checking if build backend supports build_editable exited with 1`

This is due to lacking an implementation of PEP660's prepare_metadata_for_build_editable.
