### PR TITLE
MAINT: restructure the interface between the project class and the wheel builder

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -737,16 +737,7 @@ class Project():
         ]
         if reconfigure:
             setup_args.insert(0, '--reconfigure')
-
         self._run(['meson', 'setup', *setup_args])
-
-    @cached_property
-    def _wheel_builder(self) -> _WheelBuilder:
-        return _WheelBuilder(
-            self._metadata,
-            self._manifest,
-            self._limited_api,
-        )
 
     @property
     def _build_command(self) -> List[str]:
@@ -891,13 +882,15 @@ class Project():
     def wheel(self, directory: Path) -> pathlib.Path:
         """Generates a wheel (binary distribution) in the specified directory."""
         self.build()
-        file = self._wheel_builder.build(directory)
+        builder = _WheelBuilder(self._metadata, self._manifest, self._is_pure, self._limited_api)
+        file = builder.build(directory)
         assert isinstance(file, pathlib.Path)
         return file
 
     def editable(self, directory: Path) -> pathlib.Path:
         self.build()
-        file = self._wheel_builder.build_editable(directory, self._source_dir, self._build_dir, self._build_command, self._editable_verbose)
+        builder = _WheelBuilder(self._metadata, self._manifest, self._is_pure, self._limited_api)
+        file = builder.build_editable(directory, self._source_dir, self._build_dir, self._build_command, self._editable_verbose)
         assert isinstance(file, pathlib.Path)
         return file
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -283,7 +283,7 @@ class _WheelBuilder():
     @property
     def basename(self) -> str:
         """Normalized wheel name and version."""
-        return f'{self.normalized_name}-{self._project.version}'
+        return f'{self.normalized_name}-{self._metadata.version}'
 
     @property
     def tag(self) -> mesonpy._tags.Tag:

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -437,7 +437,7 @@ class _WheelBuilder():
 
     def _wheel_write_metadata(self, whl: mesonpy._wheelfile.WheelFile) -> None:
         # add metadata
-        whl.writestr(f'{self.distinfo_dir}/METADATA', self._project.metadata)
+        whl.writestr(f'{self.distinfo_dir}/METADATA', bytes(self._metadata.as_rfc822()))
         whl.writestr(f'{self.distinfo_dir}/WHEEL', self.wheel)
         if self.entrypoints_txt:
             whl.writestr(f'{self.distinfo_dir}/entry_points.txt', self.entrypoints_txt)
@@ -839,11 +839,6 @@ class Project():
         """Project version."""
         return str(self._metadata.version)
 
-    @cached_property
-    def metadata(self) -> bytes:
-        """Project metadata as an RFC822 message."""
-        return bytes(self._metadata.as_rfc822())
-
     @property
     def license_file(self) -> Optional[pathlib.Path]:
         license_ = self._metadata.license
@@ -911,8 +906,9 @@ class Project():
             # add PKG-INFO to dist file to make it a sdist
             pkginfo_info = tarfile.TarInfo(f'{dist_name}/PKG-INFO')
             pkginfo_info.mtime = time.time()  # type: ignore[assignment]
-            pkginfo_info.size = len(self.metadata)
-            tar.addfile(pkginfo_info, fileobj=io.BytesIO(self.metadata))
+            metadata = bytes(self._metadata.as_rfc822())
+            pkginfo_info.size = len(metadata)
+            tar.addfile(pkginfo_info, fileobj=io.BytesIO(metadata))
 
         return sdist
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -311,6 +311,13 @@ class _WheelBuilder():
     def data_dir(self) -> str:
         return f'{self.basename}.data'
 
+    @property
+    def _license_file(self) -> Optional[pathlib.Path]:
+        license_ = self._metadata.license
+        if license_:
+            return license_.file
+        return None
+
     @cached_property
     def is_pure(self) -> bool:
         """Is the wheel "pure" (architecture independent)?"""
@@ -443,11 +450,8 @@ class _WheelBuilder():
             whl.writestr(f'{self.distinfo_dir}/entry_points.txt', self.entrypoints_txt)
 
         # add license (see https://github.com/mesonbuild/meson-python/issues/88)
-        if self._project.license_file:
-            whl.write(
-                self._source_dir / self._project.license_file,
-                f'{self.distinfo_dir}/{os.path.basename(self._project.license_file)}',
-            )
+        if self._license_file:
+            whl.write(self._license_file, f'{self.distinfo_dir}/{os.path.basename(self._license_file)}')
 
     def build(self, directory: Path) -> pathlib.Path:
         # ensure project is built
@@ -838,13 +842,6 @@ class Project():
     def version(self) -> str:
         """Project version."""
         return str(self._metadata.version)
-
-    @property
-    def license_file(self) -> Optional[pathlib.Path]:
-        license_ = self._metadata.license
-        if license_ and license_.file:
-            return pathlib.Path(license_.file)
-        return None
 
     @property
     def is_pure(self) -> bool:

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -880,19 +880,16 @@ class Project():
         return sdist
 
     def wheel(self, directory: Path) -> pathlib.Path:
-        """Generates a wheel (binary distribution) in the specified directory."""
+        """Generates a wheel in the specified directory."""
         self.build()
         builder = _WheelBuilder(self._metadata, self._manifest, self._is_pure, self._limited_api)
-        file = builder.build(directory)
-        assert isinstance(file, pathlib.Path)
-        return file
+        return builder.build(directory)
 
     def editable(self, directory: Path) -> pathlib.Path:
+        """Generates an editable wheel in the specified directory."""
         self.build()
         builder = _WheelBuilder(self._metadata, self._manifest, self._is_pure, self._limited_api)
-        file = builder.build_editable(directory, self._source_dir, self._build_dir, self._build_command, self._editable_verbose)
-        assert isinstance(file, pathlib.Path)
-        return file
+        return builder.build_editable(directory, self._source_dir, self._build_dir, self._build_command, self._editable_verbose)
 
 
 @contextlib.contextmanager

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -278,7 +278,7 @@ class _WheelBuilder():
 
     @property
     def normalized_name(self) -> str:
-        return self._project.name.replace('-', '_')
+        return self._metadata.name.replace('-', '_')
 
     @property
     def basename(self) -> str:
@@ -425,7 +425,7 @@ class _WheelBuilder():
                 # directory, in the form of a relative RPATH entry. meson-python
                 # relocates the shared libraries to the $project.mesonpy.libs
                 # folder. Rewrite the RPATH to point to that folder instead.
-                libspath = os.path.relpath(f'.{self._project.name}.mesonpy.libs', destination.parent)
+                libspath = os.path.relpath(f'.{self.normalized_name}.mesonpy.libs', destination.parent)
                 mesonpy._rpath.fix_rpath(origin, libspath)
 
         try:
@@ -469,7 +469,7 @@ class _WheelBuilder():
                             pass
                         elif path == 'mesonpy-libs':
                             # custom installation path for bundled libraries
-                            dst = pathlib.Path(f'.{self._project.name}.mesonpy.libs', dst)
+                            dst = pathlib.Path(f'.{self.normalized_name}.mesonpy.libs', dst)
                         else:
                             dst = pathlib.Path(self.data_dir, path, dst)
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -283,12 +283,14 @@ class _WheelBuilder():
         source_dir: pathlib.Path,
         build_dir: pathlib.Path,
         manifest: Dict[str, List[Tuple[pathlib.Path, str]]],
+        limited_api: bool,
     ) -> None:
         self._project = project
         self._metadata = metadata
         self._source_dir = source_dir
         self._build_dir = build_dir
         self._manifest = manifest
+        self._limited_api = limited_api
 
     @property
     def _has_internal_libs(self) -> bool:
@@ -385,7 +387,7 @@ class _WheelBuilder():
 
     @cached_property
     def _stable_abi(self) -> Optional[str]:
-        if self._project._limited_api:
+        if self._limited_api:
             # Verify stabe ABI compatibility: examine files installed
             # in {platlib} that look like extension modules, and raise
             # an exception if any of them has a Python version
@@ -758,6 +760,7 @@ class Project():
             self._source_dir,
             self._build_dir,
             self._manifest,
+            self._limited_api,
         )
 
     @property

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -278,17 +278,11 @@ class _WheelBuilder():
 
     def __init__(
         self,
-        project: Project,
         metadata: Metadata,
-        source_dir: pathlib.Path,
-        build_dir: pathlib.Path,
         manifest: Dict[str, List[Tuple[pathlib.Path, str]]],
         limited_api: bool,
     ) -> None:
-        self._project = project
         self._metadata = metadata
-        self._source_dir = source_dir
-        self._build_dir = build_dir
         self._manifest = manifest
         self._limited_api = limited_api
 
@@ -749,10 +743,7 @@ class Project():
     @cached_property
     def _wheel_builder(self) -> _WheelBuilder:
         return _WheelBuilder(
-            self,
             self._metadata,
-            self._source_dir,
-            self._build_dir,
             self._manifest,
             self._limited_api,
         )

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -452,9 +452,6 @@ class _WheelBuilder():
             whl.write(self._license_file, f'{self.distinfo_dir}/{os.path.basename(self._license_file)}')
 
     def build(self, directory: Path) -> pathlib.Path:
-        # ensure project is built
-        self._project.build()
-
         wheel_file = pathlib.Path(directory, f'{self.name}.whl')
         with mesonpy._wheelfile.WheelFile(wheel_file, 'w') as whl:
             self._wheel_write_metadata(whl)
@@ -480,11 +477,7 @@ class _WheelBuilder():
         return wheel_file
 
     def build_editable(self, directory: Path, verbose: bool = False) -> pathlib.Path:
-        # ensure project is built
-        self._project.build()
-
         wheel_file = pathlib.Path(directory, f'{self.name}.whl')
-
         with mesonpy._wheelfile.WheelFile(wheel_file, 'w') as whl:
             self._wheel_write_metadata(whl)
             whl.writestr(
@@ -905,11 +898,13 @@ class Project():
 
     def wheel(self, directory: Path) -> pathlib.Path:
         """Generates a wheel (binary distribution) in the specified directory."""
+        self.build()
         file = self._wheel_builder.build(directory)
         assert isinstance(file, pathlib.Path)
         return file
 
     def editable(self, directory: Path) -> pathlib.Path:
+        self.build()
         file = self._wheel_builder.build_editable(directory, self._editable_verbose)
         assert isinstance(file, pathlib.Path)
         return file

--- a/tests/packages/purelib-and-platlib/meson.build
+++ b/tests/packages/purelib-and-platlib/meson.build
@@ -6,10 +6,14 @@ project('purelib-and-platlib', 'c', version: '1.0.0')
 
 py = import('python').find_installation()
 
-py.install_sources('pure.py')
+py.install_sources(
+    'pure.py',
+    install_tag: 'purelib',
+)
 
 py.extension_module(
     'plat',
     'plat.c',
     install: true,
+    install_tag: 'platlib',
 )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -153,7 +153,7 @@ def test_install_tags(package_purelib_and_platlib, tmp_path_session):
             'install': ['--tags', 'purelib'],
         }
     )
-    assert project.is_pure
+    assert 'platlib' not in project._manifest
 
 
 def test_validate_pyproject_config_one():

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -65,10 +65,9 @@ def test_python_host_platform(monkeypatch):
 def wheel_builder_test_factory(monkeypatch, content, limited_api=False):
     files = defaultdict(list)
     files.update({key: [(pathlib.Path(x), os.path.join('build', x)) for x in value] for key, value in content.items()})
-    monkeypatch.setattr(mesonpy._WheelBuilder, '_wheel_files', files)
     class Project:
         _limited_api = limited_api
-    return mesonpy._WheelBuilder(Project(), None, pathlib.Path(), pathlib.Path(), pathlib.Path())
+    return mesonpy._WheelBuilder(Project(), None, pathlib.Path(), pathlib.Path(), files)
 
 
 def test_tag_empty_wheel(monkeypatch):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -62,33 +62,33 @@ def test_python_host_platform(monkeypatch):
     assert mesonpy._tags.get_platform_tag().endswith('x86_64')
 
 
-def wheel_builder_test_factory(monkeypatch, content, pure=True, limited_api=False):
+def wheel_builder_test_factory(content, pure=True, limited_api=False):
     manifest = defaultdict(list)
     manifest.update({key: [(pathlib.Path(x), os.path.join('build', x)) for x in value] for key, value in content.items()})
     return mesonpy._WheelBuilder(None, manifest, limited_api)
 
 
-def test_tag_empty_wheel(monkeypatch):
-    builder = wheel_builder_test_factory(monkeypatch, {})
+def test_tag_empty_wheel():
+    builder = wheel_builder_test_factory({})
     assert str(builder.tag) == 'py3-none-any'
 
 
-def test_tag_purelib_wheel(monkeypatch):
-    builder = wheel_builder_test_factory(monkeypatch, {
+def test_tag_purelib_wheel():
+    builder = wheel_builder_test_factory({
         'purelib': ['pure.py'],
     })
     assert str(builder.tag) == 'py3-none-any'
 
 
-def test_tag_platlib_wheel(monkeypatch):
-    builder = wheel_builder_test_factory(monkeypatch, {
+def test_tag_platlib_wheel():
+    builder = wheel_builder_test_factory({
         'platlib': [f'extension{SUFFIX}'],
     })
     assert str(builder.tag) == f'{INTERPRETER}-{ABI}-{PLATFORM}'
 
 
-def test_tag_stable_abi(monkeypatch):
-    builder = wheel_builder_test_factory(monkeypatch, {
+def test_tag_stable_abi():
+    builder = wheel_builder_test_factory({
         'platlib': [f'extension{ABI3SUFFIX}'],
     }, limited_api=True)
     assert str(builder.tag) == f'{INTERPRETER}-abi3-{PLATFORM}'
@@ -96,8 +96,8 @@ def test_tag_stable_abi(monkeypatch):
 
 @pytest.mark.skipif(sys.version_info < (3, 8) and sys.platform == 'win32',
                     reason='Extension modules filename suffix without ABI tags')
-def test_tag_mixed_abi(monkeypatch):
-    builder = wheel_builder_test_factory(monkeypatch, {
+def test_tag_mixed_abi():
+    builder = wheel_builder_test_factory({
         'platlib': [f'extension{ABI3SUFFIX}', f'another{SUFFIX}'],
     }, pure=False, limited_api=True)
     with pytest.raises(mesonpy.BuildError, match='The package declares compatibility with Python limited API but '):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -65,9 +65,7 @@ def test_python_host_platform(monkeypatch):
 def wheel_builder_test_factory(monkeypatch, content, pure=True, limited_api=False):
     files = defaultdict(list)
     files.update({key: [(pathlib.Path(x), os.path.join('build', x)) for x in value] for key, value in content.items()})
-    class Project:
-        _limited_api = limited_api
-    return mesonpy._WheelBuilder(Project(), None, pathlib.Path(), pathlib.Path(), files)
+    return mesonpy._WheelBuilder(None, None, pathlib.Path(), pathlib.Path(), files, limited_api)
 
 
 def test_tag_empty_wheel(monkeypatch):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -62,7 +62,7 @@ def test_python_host_platform(monkeypatch):
     assert mesonpy._tags.get_platform_tag().endswith('x86_64')
 
 
-def wheel_builder_test_factory(monkeypatch, content, limited_api=False):
+def wheel_builder_test_factory(monkeypatch, content, pure=True, limited_api=False):
     files = defaultdict(list)
     files.update({key: [(pathlib.Path(x), os.path.join('build', x)) for x in value] for key, value in content.items()})
     class Project:
@@ -92,7 +92,7 @@ def test_tag_platlib_wheel(monkeypatch):
 def test_tag_stable_abi(monkeypatch):
     builder = wheel_builder_test_factory(monkeypatch, {
         'platlib': [f'extension{ABI3SUFFIX}'],
-    }, True)
+    }, limited_api=True)
     assert str(builder.tag) == f'{INTERPRETER}-abi3-{PLATFORM}'
 
 
@@ -101,6 +101,6 @@ def test_tag_stable_abi(monkeypatch):
 def test_tag_mixed_abi(monkeypatch):
     builder = wheel_builder_test_factory(monkeypatch, {
         'platlib': [f'extension{ABI3SUFFIX}', f'another{SUFFIX}'],
-    }, True)
+    }, pure=False, limited_api=True)
     with pytest.raises(mesonpy.BuildError, match='The package declares compatibility with Python limited API but '):
         assert str(builder.tag) == f'{INTERPRETER}-abi3-{PLATFORM}'

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -63,9 +63,9 @@ def test_python_host_platform(monkeypatch):
 
 
 def wheel_builder_test_factory(monkeypatch, content, pure=True, limited_api=False):
-    files = defaultdict(list)
-    files.update({key: [(pathlib.Path(x), os.path.join('build', x)) for x in value] for key, value in content.items()})
-    return mesonpy._WheelBuilder(None, None, pathlib.Path(), pathlib.Path(), files, limited_api)
+    manifest = defaultdict(list)
+    manifest.update({key: [(pathlib.Path(x), os.path.join('build', x)) for x in value] for key, value in content.items()})
+    return mesonpy._WheelBuilder(None, manifest, limited_api)
 
 
 def test_tag_empty_wheel(monkeypatch):

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -232,12 +232,14 @@ def test_entrypoints(wheel_full_metadata):
 
 def test_top_level_modules(package_module_types):
     with mesonpy._project() as project:
-        assert set(project._wheel_builder.top_level_modules) == {
+        builder = mesonpy._WheelBuilder(project._metadata, project._manifest, project._is_pure, project._limited_api)
+        assert set(builder.top_level_modules) == {
             'file',
             'package',
             'namespace',
             'native',
         }
+
 
 def test_purelib_platlib_split(package_purelib_platlib_split, tmp_path):
     with pytest.raises(mesonpy.BuildError, match='The purelib-platlib-split package is split'):

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -232,8 +232,8 @@ def test_entrypoints(wheel_full_metadata):
 
 def test_top_level_modules(package_module_types):
     with mesonpy._project() as project:
-        builder = mesonpy._WheelBuilder(project._metadata, project._manifest, project._is_pure, project._limited_api)
-        assert set(builder.top_level_modules) == {
+        builder = mesonpy._EditableWheelBuilder(project._metadata, project._manifest, project._limited_api)
+        assert set(builder._top_level_modules) == {
             'file',
             'package',
             'namespace',


### PR DESCRIPTION
This is an attempt at making the interface between the wheel builder class and the class representing the meson project a bit easier to understand.  Ideally we should be able to just pass the manifest and the metadata to the wheel builder class.