### PR TITLE
ENH: always require patchelf on Linux

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -85,14 +85,6 @@ _NINJA_REQUIRED_VERSION = '1.8.2'
 _MESON_REQUIRED_VERSION = '0.63.3' # keep in sync with the version requirement in pyproject.toml
 
 
-class _depstr:
-    """Namespace that holds the requirement strings for dependencies we *might*
-    need at runtime. Having them in one place makes it easier to update.
-    """
-    patchelf = 'patchelf >= 0.11.0'
-    ninja = f'ninja >= {_NINJA_REQUIRED_VERSION}'
-
-
 def _init_colors() -> Dict[str, str]:
     """Detect if we should be using colors in the output. We will enable colors
     if running in a TTY, and no environment variable overrides it. Setting the
@@ -1017,12 +1009,13 @@ def _pyproject_hook(func: Callable[P, T]) -> Callable[P, T]:
 
 
 @_pyproject_hook
-def get_requires_for_build_sdist(
-    config_settings: Optional[Dict[str, str]] = None,
-) -> List[str]:
+def get_requires_for_build_sdist(config_settings: Optional[Dict[str, str]] = None) -> List[str]:
+    dependencies = []
+
     if os.environ.get('NINJA') is None and _env_ninja_command() is None:
-        return [_depstr.ninja]
-    return []
+        dependencies.append(f'ninja >= {_NINJA_REQUIRED_VERSION}')
+
+    return dependencies
 
 
 @_pyproject_hook
@@ -1042,10 +1035,10 @@ def get_requires_for_build_wheel(config_settings: Optional[Dict[str, str]] = Non
     dependencies = []
 
     if os.environ.get('NINJA') is None and _env_ninja_command() is None:
-        dependencies.append(_depstr.ninja)
+        dependencies.append(f'ninja >= {_NINJA_REQUIRED_VERSION}')
 
     if sys.platform.startswith('linux') and not shutil.which('patchelf'):
-        dependencies.append(_depstr.patchelf)
+        dependencies.append('patchelf >= 0.11.0')
 
     return dependencies
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -1038,27 +1038,14 @@ def build_sdist(
 
 
 @_pyproject_hook
-def get_requires_for_build_wheel(
-    config_settings: Optional[Dict[str, str]] = None,
-) -> List[str]:
+def get_requires_for_build_wheel(config_settings: Optional[Dict[str, str]] = None) -> List[str]:
     dependencies = []
 
     if os.environ.get('NINJA') is None and _env_ninja_command() is None:
         dependencies.append(_depstr.ninja)
 
-    if sys.platform.startswith('linux'):
-        # we may need patchelf
-        if not shutil.which('patchelf'):
-            # patchelf not already accessible on the system
-            if _env_ninja_command() is not None:
-                # we have ninja available, so we can run Meson and check if the project needs patchelf
-                with _project(config_settings) as project:
-                    if not project.is_pure:
-                        dependencies.append(_depstr.patchelf)
-            else:
-                # we can't check if the project needs patchelf, so always add it
-                # XXX: wait for https://github.com/mesonbuild/meson/pull/10779
-                dependencies.append(_depstr.patchelf)
+    if sys.platform.startswith('linux') and not shutil.which('patchelf'):
+        dependencies.append(_depstr.patchelf)
 
     return dependencies
 

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -12,15 +12,10 @@ import pytest
 
 import mesonpy
 
-from mesonpy._util import chdir
 
-from .conftest import package_dir
-
-
-@pytest.mark.parametrize('package', ['pure', 'library'])
 @pytest.mark.parametrize('system_patchelf', ['patchelf', None], ids=['patchelf', 'nopatchelf'])
 @pytest.mark.parametrize('ninja', [None, '1.8.1', '1.8.3'], ids=['noninja', 'oldninja', 'newninja'])
-def test_get_requires_for_build_wheel(monkeypatch, package, system_patchelf, ninja):
+def test_get_requires_for_build_wheel(monkeypatch, package_pure, system_patchelf, ninja):
     # the NINJA environment variable affects the ninja executable lookup and breaks the test
     monkeypatch.delenv('NINJA', raising=False)
 
@@ -51,14 +46,10 @@ def test_get_requires_for_build_wheel(monkeypatch, package, system_patchelf, nin
     if not ninja_available:
         expected |= {mesonpy._depstr.ninja}
 
-    if (
-        system_patchelf is None and sys.platform.startswith('linux')
-        and (not ninja_available or (ninja_available and package != 'pure'))
-    ):
+    if system_patchelf is None and sys.platform.startswith('linux'):
         expected |= {mesonpy._depstr.patchelf}
 
-    with chdir(package_dir / package):
-        assert set(mesonpy.get_requires_for_build_wheel()) == expected
+    assert set(mesonpy.get_requires_for_build_wheel()) == expected
 
 
 def test_invalid_config_settings(capsys, package_pure, tmp_path_session):


### PR DESCRIPTION
patchelf is required on Linux when executables, libraries, or extension modules in the package link to a shared library itself also distributed with the package.

To determine whether patchelf is required, the project to be built into a wheel needs to be configured. Because ephemeral build directories are used, the project needs to be configured a second time when the wheel is actually built. For all but the simplest projects the time spent in ``meson setup`` is significant.

This patch removes the check and thus the requirement for configuring the project twice, and assumes that patchelf is always required on Linux: dependency on the patchelf package is added when a suitable patchelf executable is not found in the environment.

Configuring the project requires ninja to be available. When ninja is not available the it was assumed that patchelf is required. The check was also implemented incorrectly and did not actually check whether a shared library is included in the wheel. Therefore, this patch changes whether the patchelf package is installed only when projects that do not include any native code components that are build on systems where ninja is available an patchelf is not.

The impact of this change is largest for pure Python projects. To measure it, I timed the time required to build wheels for meson-python itself with ninja and patchelf installed or not in the environment:
```
  ninja  patchelf  main          this
  -----  --------  ------------  ------------
  no     no        6.5 +- 0.3 s  6.5 +- 0.3 s
  yes    no        6.0 +- 0.3 s  5.8 +- 0.3 s
  yes    yes       5.6 +- 0.6 s  5.6 +- 0.6 s
```
Timings are from 7 consecutive runs of ``python -m pip wheel``. All the required dependencies are in the pip cache. Using ``python -m build -w`` the build time is around 9 seconds and is dominated by the time requires to install pip in the isolated build environment, so the run time differences less pronounced. Scatter in the data is dominated by the network round trip times of pip checking the package index for the dependencies latest versions.

Even in the least favorable case, this change does not have a negative impact on the wheel build time.