### PR TITLE
ENH: count installed files starting at one

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -419,7 +419,7 @@ class _WheelBuilder():
         with mesonpy._wheelfile.WheelFile(wheel_file, 'w') as whl:
             self._wheel_write_metadata(whl)
 
-            with mesonpy._util.cli_counter(sum(len(x) for x in self._manifest.values())) as counter:
+            with mesonpy._util.clicounter(sum(len(x) for x in self._manifest.values())) as counter:
 
                 root = 'purelib' if self._pure else 'platlib'
 

--- a/mesonpy/_compat.py
+++ b/mesonpy/_compat.py
@@ -40,6 +40,11 @@ if typing.TYPE_CHECKING:
     else:
         from typing_extensions import ParamSpec
 
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
+
     Path = Union[str, os.PathLike]
 
 
@@ -52,5 +57,6 @@ __all__ = [
     'Mapping',
     'Path',
     'ParamSpec',
+    'Self',
     'Sequence',
 ]

--- a/mesonpy/_util.py
+++ b/mesonpy/_util.py
@@ -53,8 +53,8 @@ def create_targz(path: Path) -> Iterator[tarfile.TarFile]:
 
 class CLICounter:
     def __init__(self, total: int) -> None:
-        self._total = total - 1
-        self._count = itertools.count()
+        self._total = total
+        self._count = itertools.count(start=1)
 
     def update(self, description: str) -> None:
         line = f'[{next(self._count)}/{self._total}] {description}'

--- a/mesonpy/_util.py
+++ b/mesonpy/_util.py
@@ -18,7 +18,9 @@ from typing import IO
 
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from mesonpy._compat import Iterator, Path
+    from typing import Any
+
+    from mesonpy._compat import Iterator, Path, Self
 
 
 @contextlib.contextmanager
@@ -51,10 +53,13 @@ def create_targz(path: Path) -> Iterator[tarfile.TarFile]:
         yield tar
 
 
-class CLICounter:
+class clicounter:
     def __init__(self, total: int) -> None:
         self._total = total
         self._count = itertools.count(start=1)
+
+    def __enter__(self) -> Self:
+        return self
 
     def update(self, description: str) -> None:
         line = f'[{next(self._count)}/{self._total}] {description}'
@@ -63,13 +68,6 @@ class CLICounter:
         else:
             print(line)
 
-    def finish(self) -> None:
+    def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
         if sys.stdout.isatty():
             print()
-
-
-@contextlib.contextmanager
-def cli_counter(total: int) -> Iterator[CLICounter]:
-    counter = CLICounter(total)
-    yield counter
-    counter.finish()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
   'pytest-mock',
   'cython >= 0.29.34', # required for Python 3.12 support
   'wheel',
-  'typing-extensions >= 3.7.4; python_version < "3.10"',
+  'typing-extensions >= 3.7.4; python_version < "3.11"',
 ]
 docs = [
   'furo >= 2021.08.31',


### PR DESCRIPTION
Counting starting at zero is nice and nerdy, but logging that meson-python is installing zero of zero files when is actually installing something is confusing.