### PR TITLE
MAIN: add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2023 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+Matthias Köppe <mkoeppe@math.ucdavis.edu>
+Yue Yang <metab0t@outlook.com>


### PR DESCRIPTION
The added mailmap files fixes two alternative spellings of Matthias Köppe's name and adds a name for metab0t beside the Github username. This is useful for generating the contributors list we add to the changelog.