### PR TITLE
BUG: Fix wheels not being compressed

### DIFF
--- a/mesonpy/_wheelfile.py
+++ b/mesonpy/_wheelfile.py
@@ -87,7 +87,10 @@ class WheelFileWriter(WheelFile):
         else:
             zinfo = zipfile.ZipInfo(zinfo_or_arcname, date_time=self.timestamp())
             zinfo.external_attr = 0o664 << 16
-        self.archive.writestr(zinfo, data)
+        self.archive.writestr(
+            zinfo, data,
+            compress_type=self.archive.compression,
+            compresslevel=self.archive.compresslevel)
         self.entries.append((zinfo.filename, self.hash(data), len(data)))
 
     def write(self, filename: Path, arcname: Optional[str] = None) -> None:
@@ -106,5 +109,8 @@ class WheelFileWriter(WheelFile):
         writer.writerow((record, '', ''))
         zi = zipfile.ZipInfo(record, date_time=self.timestamp())
         zi.external_attr = 0o664 << 16
-        self.archive.writestr(zi, data.getvalue())
+        self.archive.writestr(
+            zi, data.getvalue(),
+            compress_type=self.archive.compression,
+            compresslevel=self.archive.compresslevel)
         self.archive.close()

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import time
+import zipfile
 
 import wheel.wheelfile
 
@@ -41,3 +42,16 @@ def test_source_date_epoch(tmp_path, monkeypatch):
     with wheel.wheelfile.WheelFile(path, 'r') as w:
         for entry in w.infolist():
             assert entry.date_time == time.gmtime(epoch)[:6]
+
+
+def test_compression(tmp_path):
+    # create a wheel and test that everything is compressed
+    path = tmp_path / 'test-1.0-py3-any-none.whl'
+    bar = tmp_path / 'bar'
+    bar.write_bytes(b'bar')
+    with mesonpy._wheelfile.WheelFile(path, 'w') as w:
+        w.writestr('foo', b'test')
+        w.write(bar, 'bar')
+    with zipfile.ZipFile(path, 'r') as w:
+        for entry in w.infolist():
+            assert entry.compress_type == zipfile.ZIP_DEFLATED


### PR DESCRIPTION
As pointed out in
https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.writestr
when creating a ZipInfo it defaults to ZIP_STORED and when passing it
to writestr it will use the compression info from the ZipInfo instance
instead of the ZipFile. This leads to the wheel file being
uncompressed.

To fix this explicitely specify the compression type and level for
writestr() so it gets applied to the ZipInfo instance before writing.
While the compression level currently isn't used I also added it to
avoid future surprises.

Fixes #519