### PR TITLE
DOC/REL: prepare 0.15.0 changelog and release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,38 @@
 Changelog
 +++++++++
 
+0.15.0
+======
+
+- Enable compression for wheel files. The may result in several times
+  smaller wheels.
+- Require Meson 1.2.3 or later on Python 3.12 or later. Meson 1.2.3
+  does not require anymore ``distutils``, allowing to remove the
+  dependency on ``setuptools`` on Python 3.12 or later.
+- Unconditionally require ``patchelf`` on Linux.  The ``patchelf``
+  package is added to the build dependencies if a suitable
+  ``patchelf`` executable is not find on the ``$PATH``. This avoids
+  cases where ``meson setup`` was run twice during the build process
+  to determine whether ``patchelf`` is required.
+- Allow to configure the ``meson`` executable to use for the build
+  process through the ``$MESON`` environment variable or the ``meson``
+  key under ``[tool.meson-python]`` in ``pyproject.toml``.
+- Fix wheel platform tag generation on FreeBSD.
+- Extend support to other UNIX-like systems and make the tests pass on
+  FreeBSD.
+- Fix package name normalization in package metadata and improve
+  package name validation.
+- Fix ``RPATH`` handling when the build ``RPATH`` points to
+  subdirectories of the build directory.
+- Fix support for the Python limited C API when compiling for PyPy.
+- Rename the ``builddir`` config-setting to ``build-dir``. For
+  backwards compatibility, the ``buildir`` config-setting remains
+  supported as an alias.
+
+Christoph Reiter, Daniele Nicolodi, Elliott Sales de Andrade, Ralf Gommers,
+Yue Yang --- 26-10-2023
+
+
 0.14.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Changelog
 - Implement support for building wheels targeting the Python limited
   API. Extension modules targeting the Python limited API can be
   easily built starting with the upcoming Meson 1.3.0 release.
-- when ``pyproject.toml`` does not contain a ``version`` field and
+- When ``pyproject.toml`` does not contain a ``version`` field and
   ``version`` is not declared dynamic, raise an error instead of
   silently using the version declared in ``meson.build``.
 - Fix the mtime of source files in the sdist tarball.

--- a/docs/reference/config-settings.rst
+++ b/docs/reference/config-settings.rst
@@ -27,7 +27,7 @@ them.
    ``meson-python``. This avoids having to rebuild the whole project
    when testing changes during development.
 
-   For backward comaptibility reasons, the alternative ``builddir``
+   For backward compatibility reasons, the alternative ``builddir``
    spelling is also accepted.
 
 .. option:: dist-args

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-project('meson-python', version: '0.15.0.dev0')
+project('meson-python', version: '0.15.0')
 
 py = import('python').find_installation()
 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-project('meson-python', version: '0.15.0')
+project('meson-python', version: '0.16.0.dev0')
 
 py = import('python').find_installation()
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -65,7 +65,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     MesonArgs = Mapping[MesonArgsKeys, List[str]]
 
 
-__version__ = '0.15.0.dev0'
+__version__ = '0.15.0'
 
 
 _NINJA_REQUIRED_VERSION = '1.8.2'

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -65,7 +65,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     MesonArgs = Mapping[MesonArgsKeys, List[str]]
 
 
-__version__ = '0.15.0'
+__version__ = '0.16.0.dev0'
 
 
 _NINJA_REQUIRED_VERSION = '1.8.2'


### PR DESCRIPTION
We accumulated a few important bug fixes and new features, so it seems time for a release.

@dnicolodi I set the date to today - in case it gets merged later, that date should be updated right before the merge.