### PR TITLE
DOC: fix Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,8 +4,12 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
The problem was that they migrated to a new yaml version, plus that notifications on build failures in the RTD UI was not enabled for anyone.

Closes gh-522