### PR TITLE
BUG: fix detection of platform dependent components in wheel

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -302,7 +302,7 @@ class _WheelBuilder():
     @cached_property
     def _pure(self) -> bool:
         """Whether the wheel is architecture independent"""
-        if self._manifest['platlib']:
+        if self._manifest['platlib'] or self._manifest['mesonpy-libs']:
             return False
         for _, file in self._manifest['scripts']:
             if _is_native(file):


### PR DESCRIPTION
Correctly detect a wheel shipping shared libraries as being platform dependent also when it does not ship compiled executables or Python extension modules.