### PR TITLE
BUG: use 11.0 as minimum macOS platform ABI tag on arm64

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,3 +80,9 @@ freebsd_task:
     image_family: freebsd-13-2
   install_script: pkg install -y git ninja
   << : *test
+
+macos-arm64_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-xcode
+  install_script: brew install git ninja python@3.11
+  << : *test

--- a/mesonpy/_tags.py
+++ b/mesonpy/_tags.py
@@ -129,6 +129,16 @@ def _get_macosx_platform_tag() -> str:
     # can therefore ignore the issue and generate the slightly
     # incorrect tag.
 
+    # The minimum macOS ABI version on arm64 is 11.0.  The macOS SDK
+    # on arm64 silently bumps any compatibility version specified via
+    # the MACOSX_DEPLOYMENT_TARGET environment variable to 11.0.
+    # Despite the platform ABI tag being intended to be a minimum
+    # compatibility version, pip refuses to install wheels with a
+    # platform tag specifying an ABI version lower than 11.0.  Use
+    # 11.0 as minimum ABI version on arm64.
+    if arch == 'arm64' and version < (11, 0):
+        version = (11, 0)
+
     major, minor = version
 
     if major >= 11:


### PR DESCRIPTION
Fixes #524.