### PR TITLE
MAINT: use placeholder email address for Thomas Li in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ maintainers = [
   { name = 'Ralf Gommers ', email = 'ralf.gommers@gmail.com' },
   { name = 'Daniele Nicolodi', email = 'daniele@grinta.net' },
   { name = 'Henry Schreiner', email = 'HenrySchreinerIII@gmail.com' },
-  { name = 'Thomas Li'},
+  { name = 'Thomas Li', email = '47963215+lithomas1@users.noreply.github.com' },
 ]
 classifiers = [
   'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This is the same email address that is used in the for the git commits. This should fix how the Maintainers metadata field is rendered on the PyPI package page.