### PR TITLE
DOC: deploy documentation using Github Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ name: docs
 
 on:
   push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main
@@ -14,14 +16,36 @@ on:
       - docs/**
       - CHANGELOG.rst
       - README.md
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
 
 jobs:
-  docs:
+
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.push.tag || github.event.inputs.tag }}
       - run: python -m pip install .[docs]
       - run: python -m sphinx docs/ build/docs/
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: build/docs/
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+    runs-on: ubuntu-latest
+    if: ${{ github.event.push.tag || github.event.inputs.tag }}
+    steps:
+      - uses: actions/deploy-pages@v2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,6 @@ meson-python
    build-system. It enables you to use Meson for your Python packages.
 
 
-Want to look at examples in real projects? Check out our curated list of
-``meson-python`` projects :ref:`here <projects-using-meson-python>`.
-
-
 Where to start?
 ===============
 


### PR DESCRIPTION
This is very simple and does not allow for multiple versions of the documentation to be published. I think it would not be too hard to add, but I don't think it would add much value for the meson-python documentation.