### PR TITLE
Allow duplicate -arch in ARCHFLAGS

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -647,7 +647,7 @@ class Project():
             archflags = os.environ.get('ARCHFLAGS', '').strip()
             if archflags:
                 arch, *other = filter(None, (x.strip() for x in archflags.split('-arch')))
-                if other:
+                if [a for a in other if a != arch]:
                     raise ConfigError(f'Multi-architecture builds are not supported but $ARCHFLAGS={archflags!r}')
                 macver, _, nativearch = platform.mac_ver()
                 if arch != nativearch:

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -10,8 +10,9 @@ import subprocess
 import sys
 import sysconfig
 import textwrap
-from pathlib import Path
+
 from contextlib import contextmanager
+from pathlib import Path
 
 import packaging.tags
 import pytest


### PR DESCRIPTION
We came across a situation where the build added duplicate archs in
ARCHFLAGS, e.g. `-arch arm64 -arch arm64`.  These usually pass through
compilers etc without problem, but mesonpy was raising in that case,
accusing the build of being multiarch.   Fix and test.