### PR TITLE
Add project 'werpy' to list of projects using meson-python.

### DIFF
--- a/docs/projects-using-meson-python.rst
+++ b/docs/projects-using-meson-python.rst
@@ -30,6 +30,13 @@ Here's a curated list of projects using ``meson-python``.
        an example of how to use `cibuildwheel`_ to produce Python wheels for
        several platforms.
 
+   * - `werpy <https://github.com/analyticsinmotion/werpy>`_
+     - This project provides a straightforward example for utilizing
+       meson-python to package a Python project with compiled extensions. 
+       It shows a practical use case of integrating optimized native code 
+       written in Cython_ into a Python package through seamless 
+       cross-platform compilation.
+
 
 .. _CPython extension: https://docs.python.org/3/extending/extending.html
 .. _CPython extensions: https://docs.python.org/3/extending/extending.html


### PR DESCRIPTION
This pull request proposes the addition of our package, werpy, to the list of working examples in the meson-python documentation.

Werpy is a fast, lightweight Python package for calculating and analyzing Word Error Rate (WER) between two sets of text.

This package demonstrates a successful use case of meson-python for building and distributing Python packages with C extensions and provides a good use case for others to view.