### PR TITLE
ENH: drop dependency on colorama on Windows

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -145,7 +145,7 @@ def _map_to_wheel(sources: Dict[str, Dict[str, Any]]) -> DefaultDict[str, List[T
 
 
 class style:
-    ERROR = '\33[31m',  # red
+    ERROR = '\33[31m'  # red
     WARNING = '\33[93m'  # bright yellow
     INFO = '\33[36m\33[1m'  # cyan, bold
     RESET = '\33[0m'

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -156,8 +156,8 @@ class style:
 
 
 @functools.lru_cache()
-def _use_ansi_colors() -> bool:
-    """Determine whether logging should use ANSI color escapes."""
+def _use_ansi_escapes() -> bool:
+    """Determine whether logging should use ANSI escapes."""
 
     # We print log messages and error messages that may contain file
     # names containing characters that cannot be represented in the
@@ -167,19 +167,17 @@ def _use_ansi_colors() -> bool:
 
     if 'NO_COLOR' in os.environ:
         return False
+
     if 'FORCE_COLOR' in os.environ or sys.stdout.isatty() and os.environ.get('TERM') != 'dumb':
-        try:
-            import colorama
-        except ModuleNotFoundError:
-            pass
-        else:
-            colorama.init()
+        if sys.platform == 'win32' and not os.environ.get('ANSICON'):
+            return mesonpy._util.setup_windows_console()
         return True
+
     return False
 
 
 def _log(string: str , **kwargs: Any) -> None:
-    if not _use_ansi_colors():
+    if not _use_ansi_escapes():
         string = style.strip(string)
     print(string, **kwargs)
 

--- a/mesonpy/_util.py
+++ b/mesonpy/_util.py
@@ -71,3 +71,23 @@ class clicounter:
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
         if sys.stdout.isatty():
             print()
+
+
+def setup_windows_console() -> bool:
+    from ctypes import byref, windll  # type: ignore
+    from ctypes.wintypes import DWORD
+
+    STD_OUTPUT_HANDLE = -11
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x04
+
+    kernel = windll.kernel32
+    stdout = kernel.GetStdHandle(STD_OUTPUT_HANDLE)
+    mode = DWORD()
+
+    if not kernel.GetConsoleMode(stdout, byref(mode)):
+        return False
+
+    if not kernel.SetConsoleMode(stdout, mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING):
+        return False
+
+    return True

--- a/mesonpy/_util.py
+++ b/mesonpy/_util.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import gzip
-import itertools
 import os
-import sys
 import tarfile
 import typing
 
@@ -18,9 +16,7 @@ from typing import IO
 
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
-
-    from mesonpy._compat import Iterator, Path, Self
+    from mesonpy._compat import Iterator, Path
 
 
 @contextlib.contextmanager
@@ -51,26 +47,6 @@ def create_targz(path: Path) -> Iterator[tarfile.TarFile]:
 
     with contextlib.closing(file), tar:
         yield tar
-
-
-class clicounter:
-    def __init__(self, total: int) -> None:
-        self._total = total
-        self._count = itertools.count(start=1)
-
-    def __enter__(self) -> Self:
-        return self
-
-    def update(self, description: str) -> None:
-        line = f'[{next(self._count)}/{self._total}] {description}'
-        if sys.stdout.isatty():
-            print('\r', line, sep='', end='\33[0K', flush=True)
-        else:
-            print(line)
-
-    def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
-        if sys.stdout.isatty():
-            print()
 
 
 def setup_windows_console() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 ]
 
 dependencies = [
-  'colorama; os_name == "nt"',
   'meson >= 0.63.3; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
   'pyproject-metadata >= 0.7.1',

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -18,7 +18,7 @@ import mesonpy
     (True, {'TERM': ''}, True),
     (True, {'TERM': 'dumb'}, False),
 ])
-def test_use_ansi_colors(mocker, monkeypatch, tty, env, colors):
+def test_use_ansi_escapes(mocker, monkeypatch, tty, env, colors):
     mocker.patch('sys.stdout.isatty', return_value=tty)
     mocker.patch('mesonpy._util.setup_windows_console', return_value=True)
     monkeypatch.delenv('NO_COLOR', raising=False)
@@ -27,6 +27,6 @@ def test_use_ansi_colors(mocker, monkeypatch, tty, env, colors):
         monkeypatch.setenv(key, value)
 
     # Clear caching by functools.lru_cache().
-    mesonpy._use_ansi_colors.cache_clear()
+    mesonpy._use_ansi_escapes.cache_clear()
 
-    assert mesonpy._use_ansi_colors() == colors
+    assert mesonpy._use_ansi_escapes() == colors

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -7,22 +7,20 @@ import pytest
 import mesonpy
 
 
-@pytest.mark.parametrize(
-    ('tty', 'env', 'colors'),
-    [
-        (False, {}, False),
-        (True, {}, True),
-        (False, {'NO_COLOR': ''}, False),
-        (True, {'NO_COLOR': ''}, False),
-        (False, {'FORCE_COLOR': ''}, True),
-        (True, {'FORCE_COLOR': ''}, True),
-        (True, {'FORCE_COLOR': '', 'NO_COLOR': ''}, False),
-        (True, {'TERM': ''}, True),
-        (True, {'TERM': 'dumb'}, False),
-    ],
-)
+@pytest.mark.parametrize(('tty', 'env', 'colors'), [
+    (False, {}, False),
+    (True, {}, True),
+    (False, {'NO_COLOR': ''}, False),
+    (True, {'NO_COLOR': ''}, False),
+    (False, {'FORCE_COLOR': ''}, True),
+    (True, {'FORCE_COLOR': ''}, True),
+    (True, {'FORCE_COLOR': '', 'NO_COLOR': ''}, False),
+    (True, {'TERM': ''}, True),
+    (True, {'TERM': 'dumb'}, False),
+])
 def test_use_ansi_colors(mocker, monkeypatch, tty, env, colors):
     mocker.patch('sys.stdout.isatty', return_value=tty)
+    mocker.patch('mesonpy._util.setup_windows_console', return_value=True)
     monkeypatch.delenv('NO_COLOR', raising=False)
     monkeypatch.delenv('FORCE_COLOR', raising=False)
     for key, value in env.items():


### PR DESCRIPTION
Simply enable ANSI escape sequences processing on the Windows console. This works only on Windows 10 and later, and colorama does the same thing when it can.