### PR TITLE
macOS: fix detection of nativearch for PowerPC

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -683,7 +683,12 @@ class Project():
                 if other:
                     raise ConfigError(f'Multi-architecture builds are not supported but $ARCHFLAGS={archflags!r}')
 
-                macver, _, nativearch = platform.mac_ver()
+                if sysconfig.get_platform().endswith('-ppc64'):
+                    nativearch = 'ppc64'
+                elif sysconfig.get_platform().endswith('-ppc'):
+                    nativearch = 'ppc'
+                else:
+                    macver, _, nativearch = platform.mac_ver()
                 if arch != nativearch:
                     x = os.environ.setdefault('_PYTHON_HOST_PLATFORM', f'macosx-{macver}-{arch}')
                     if not x.endswith(arch):


### PR DESCRIPTION
(If this can be done in a simpler way, please advise me. Python is not my sphere of expertise.)

_Problem_

`platform.mac_ver()` on PowerPC is not giving a value which the code expects (this is in Rosetta):
```
macmini:macports-ports svacchanda$ /opt/local/bin/python3.11 -c 'import platform; print(platform.mac_ver())'
('10.6.8', ('', '', ''), 'PowerPC')
```
This makes the build system believe it is cross-compiling, and if the cross-file is not provided (and in `Numpy` it is not, for example), disaster ensues: https://trac.macports.org/ticket/68908

What is giving the correct values is `sysconfig.get_platform()` used in the same file just above:
```
macmini:macports-ports svacchanda$ /opt/local/bin/python3.11 -c 'import sysconfig; print(sysconfig.get_platform())'
macosx-10.6-ppc
```
It is defined for PowerPC here: https://github.com/python/cpython/blob/48c907a15ceae7202fcfeb435943addff896c42c/Lib/_osx_support.py#L566-L572
