### PR TITLE
BUG: empty __spec__.submodule_search_locations and __path__ values for editable packages

### DIFF
--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -184,6 +184,12 @@ def build_module_spec(cls: type, name: str, path: str, tree: Optional[Node]) -> 
     spec.has_location = True
     if loader.is_package(name):
         spec.submodule_search_locations = [os.path.dirname(path)]
+        if tree is not None:
+            for submodule_node in tree.values():
+                if isinstance(submodule_node, str):
+                    parent_folder = os.path.dirname(submodule_node)
+                    if parent_folder not in spec.submodule_search_locations:
+                        spec.submodule_search_locations.append(parent_folder)
     return spec
 
 

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -183,7 +183,7 @@ def build_module_spec(cls: type, name: str, path: str, tree: Optional[Node]) -> 
     spec = importlib.machinery.ModuleSpec(name, loader, origin=path)
     spec.has_location = True
     if loader.is_package(name):
-        spec.submodule_search_locations = []
+        spec.submodule_search_locations = [os.path.dirname(path)]
     return spec
 
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -4,8 +4,8 @@
 
 import os
 import pathlib
-import sys
 import pkgutil
+import sys
 
 import pytest
 
@@ -97,7 +97,7 @@ def test_mesonpy_meta_finder(package_complex, tmp_path):
         assert complex.test.__spec__.origin == os.fspath(tmp_path / f'test{EXT_SUFFIX}')
         assert complex.test.__file__ == complex.test.__spec__.origin
         assert complex.test.__spec__.submodule_search_locations is None
-        assert not hasattr(complex.test, "__path__")
+        assert not hasattr(complex.test, '__path__')
         assert complex.test.answer() == 42
         import complex.more
         assert complex.more.__spec__.origin == os.fspath(package_complex / 'complex/more/__init__.py')
@@ -117,7 +117,7 @@ def test_walk_packages(package_complex, tmp_path):
     mesonpy.Project(package_complex, tmp_path)
 
     # point the meta finder to the build directory
-    finder = _editable.MesonpyMetaFinder({"complex"}, os.fspath(tmp_path), ["ninja"])
+    finder = _editable.MesonpyMetaFinder({'complex'}, os.fspath(tmp_path), ['ninja'])
 
     try:
         # install the finder in the meta path
@@ -127,11 +127,11 @@ def test_walk_packages(package_complex, tmp_path):
 
         module_names = sorted(
             module_info.name
-            for module_info in pkgutil.walk_packages(complex.__path__, prefix="complex.")
+            for module_info in pkgutil.walk_packages(complex.__path__, prefix='complex.')
         )
         assert module_names == [
-            "complex.more",
-            "complex.test",
+            'complex.more',
+            'complex.test',
             # XXX: should namespace packages be discovered by walk_packages?
         ]
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -86,10 +86,17 @@ def test_mesonpy_meta_finder(package_complex, tmp_path):
         # verify that we can import the modules
         import complex
         assert complex.__spec__.origin == os.fspath(package_complex / 'complex/__init__.py')
-        assert complex.__file__ == os.fspath(package_complex / 'complex/__init__.py')
+        assert complex.__spec__.submodule_search_locations == [os.fspath(package_complex / 'complex')]
+        assert complex.__file__ == complex.__spec__.origin
+        assert complex.__path__ == complex.__spec__.submodule_search_locations
         import complex.test
         assert complex.test.__spec__.origin == os.fspath(tmp_path / f'test{EXT_SUFFIX}')
         assert complex.test.answer() == 42
+        import complex.more
+        assert complex.more.__spec__.origin == os.fspath(package_complex / 'complex/more/__init__.py')
+        assert complex.more.__spec__.submodule_search_locations == [os.fspath(package_complex / 'complex/more')]
+        assert complex.more.__file__ == complex.more.__spec__.origin
+        assert complex.more.__path__ == complex.more.__spec__.submodule_search_locations
         import complex.namespace.foo
         assert complex.namespace.foo.__spec__.origin == os.fspath(package_complex / 'complex/namespace/foo.py')
         assert complex.namespace.foo.foo() == 'foo'

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -91,6 +91,9 @@ def test_mesonpy_meta_finder(package_complex, tmp_path):
         assert complex.__path__ == complex.__spec__.submodule_search_locations
         import complex.test
         assert complex.test.__spec__.origin == os.fspath(tmp_path / f'test{EXT_SUFFIX}')
+        assert complex.test.__file__ == complex.test.__spec__.origin
+        assert complex.test.__spec__.submodule_search_locations is None
+        assert not hasattr(complex.test, "__path__")
         assert complex.test.answer() == 42
         import complex.more
         assert complex.more.__spec__.origin == os.fspath(package_complex / 'complex/more/__init__.py')


### PR DESCRIPTION
This should solve the problem of empty `__path__` attributes for packages imported from an editable install.

Fixes https://github.com/mesonbuild/meson-python/issues/557.