### PR TITLE
CI: extend matrix to include Meson 1.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,9 @@ jobs:
           - os: ubuntu
             python: '3.11'
             meson: '~=1.1.0'
+          - os: ubuntu
+            python: '3.12'
+            meson: '~=1.2.3'
           # Test with Meson master branch.
           - os: ubuntu
             python: '3.12'

--- a/ci/alpine-3.docker
+++ b/ci/alpine-3.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20221203
+# 20240204
 FROM alpine:3
 RUN apk add --no-cache python3-dev py3-pip build-base ninja git patchelf

--- a/ci/debian-11.docker
+++ b/ci/debian-11.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20221203
+# 20240204
 FROM debian:bullseye
 RUN apt-get update && apt-get install -y git ninja-build patchelf python3-pip python3-venv && rm -rf /var/lib/apt/lists/*

--- a/ci/debian-12.docker
+++ b/ci/debian-12.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20230816
+# 20240204
 FROM debian:bookworm
 RUN apt-get update && apt-get install -y git ninja-build patchelf python3-pip python3-venv && rm -rf /var/lib/apt/lists/*

--- a/ci/fedora-37.docker
+++ b/ci/fedora-37.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20221203
+# 20240204
 FROM fedora:37
 RUN dnf -y update && dnf -y install python3-devel python3-pip gcc ninja-build git patchelf && dnf clean all

--- a/ci/miniconda.docker
+++ b/ci/miniconda.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20221203
+# 20240204
 FROM continuumio/miniconda3
 RUN apt-get update && apt-get install -y gcc ninja-build git patchelf && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The tests are run with the latest Meson version, and Meson 1.3 has been released a while ago. Add Meson 1.2 to the old releases with test with. Pin the version to 1.2.3 or later, to be able to run on Python 3.12.