### PR TITLE
BUG: Allow installation directories

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -439,19 +439,19 @@ class _WheelBuilder():
                 libspath = os.path.relpath(self._libs_dir, destination.parent)
                 mesonpy._rpath.fix_rpath(origin, libspath)
 
-        try:
-            # handle directories recursively
-            if origin.is_dir():
-                children = [(src, destination / src.name) for src in list(origin.glob('*'))]
-                for src, dest in children:
-                    self._install_path(wheel_file, src, dest)
-            else:
+        # handle directories recursively
+        if origin.is_dir():
+            children = [(src, destination / src.name) for src in list(origin.glob('*'))]
+            for src, dest in children:
+                self._install_path(wheel_file, src, dest)
+        else:
+            try:
                 wheel_file.write(origin, destination.as_posix())
 
-        except FileNotFoundError:
-            # work around for Meson bug, see https://github.com/mesonbuild/meson/pull/11655
-            if not os.fspath(origin).endswith('.pdb'):
-                raise
+            except FileNotFoundError:
+                # work around for Meson bug, see https://github.com/mesonbuild/meson/pull/11655
+                if not os.fspath(origin).endswith('.pdb'):
+                    raise
 
     def _wheel_write_metadata(self, whl: mesonpy._wheelfile.WheelFile) -> None:
         # add metadata


### PR DESCRIPTION
Currently meson-python fails to execute a `custom_target()` which specifies a directory as output and enables installation. You need this if you have a `custom_target()` for which you don't know the exact set of output files in advance. When run directly (`meson build`, `meson install -C build`), meson installs the directory without any problems. Apparently (stated on the meson IRC channel) this is explicitly allowed in meson, although the documentation doesn't seem to either forbid or allow it explicitly. 

~~A concrete example use case is when you want to generate html documentation using `sphinx-build`, which generates not only one html page per input, but also places necessary images, css and js files into its output directory.~~

The issue is in `_install_path()` in `__init__.py` which tries to `write()` to the output file not checking if it is a regular file first.

This PR solves the issue by checking if the current path is a directory and if so calls `_install_path()` recursively on all of the path's children.