### PR TITLE
Editable install: do not show any output in  verbose mode when there is no work to do

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run tests
         run: >-
-          python -m pytest --showlocals -vv --cov --cov-report=xml -s
+          python -m pytest --showlocals -vv --cov --cov-report=xml
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run tests
         run: >-
-          python -m pytest --showlocals -vv --cov --cov-report=xml
+          python -m pytest --showlocals -vv --cov --cov-report=xml -s
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -309,7 +309,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             dry_run_build_cmd = self._build_cmd + ['-n']
             p = subprocess.run(dry_run_build_cmd, cwd=self._build_path, env=env, capture_output=True)
             if b'ninja: no work to do.' not in p.stdout and b'samu: nothing to do' not in p.stdout:
-                print('+ ' + ' '.join(self._build_cmd))
+                print('+ ' + ' '.join(self._build_cmd), flush=True)
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env)
         else:
             subprocess.run(self._build_cmd, cwd=self._build_path, env=env, stdout=subprocess.DEVNULL)

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -316,6 +316,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
         env = os.environ.copy()
         env[MARKER] = os.pathsep.join((env.get(MARKER, ''), self._build_path))
 
+        sys.stderr.write(f"{env.get(VERBOSE, '')=}\n")
         if self._verbose or bool(env.get(VERBOSE, '')):
             # We do not want any output if there is no work to do. Code is adapted from:
             # https://github.com/mesonbuild/meson/blob/a35d4d368a21f4b70afa3195da4d6292a649cb4c/mesonbuild/mtest.py#L1635-L1636

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -316,8 +316,9 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
         env = os.environ.copy()
         env[MARKER] = os.pathsep.join((env.get(MARKER, ''), self._build_path))
 
-        sys.stderr.write(f"{env.get(VERBOSE, '')=}\n")
+        sys.stderr.write('VERBOSE value:' + env.get(VERBOSE, '') + '\n')
         if self._verbose or bool(env.get(VERBOSE, '')):
+            sys.stderr.write('this line gets executed contrary to what codecov says\n')
             # We do not want any output if there is no work to do. Code is adapted from:
             # https://github.com/mesonbuild/meson/blob/a35d4d368a21f4b70afa3195da4d6292a649cb4c/mesonbuild/mtest.py#L1635-L1636
             if sys.platform == 'win32':

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -316,9 +316,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
         env = os.environ.copy()
         env[MARKER] = os.pathsep.join((env.get(MARKER, ''), self._build_path))
 
-        sys.stderr.write('VERBOSE value:' + env.get(VERBOSE, '') + '\n')
         if self._verbose or bool(env.get(VERBOSE, '')):
-            sys.stderr.write('this line gets executed contrary to what codecov says\n')
             # We do not want any output if there is no work to do. Code is adapted from:
             # https://github.com/mesonbuild/meson/blob/a35d4d368a21f4b70afa3195da4d6292a649cb4c/mesonbuild/mtest.py#L1635-L1636
             if sys.platform == 'win32':

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -308,7 +308,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
         tree = self._rebuild()
         return find_spec(fullname, tree)
 
-    def _work_to_do(self, env):
+    def _work_to_do(self, env: dict[str, str]) -> bool:
         # Code is adapted from:
         # https://github.com/mesonbuild/meson/blob/a35d4d368a21f4b70afa3195da4d6292a649cb4c/mesonbuild/mtest.py#L1635-L1636
         if sys.platform != 'win32':

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -313,7 +313,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             else:
                 dry_run_build_cmd = self._build_cmd + ['-n']
 
-            p = subprocess.run(dry_run_build_cmd, cwd=self._build_path, env=env, capture_output=True)
+            p = subprocess.run(dry_run_build_cmd, cwd=self._build_path, env=env, capture_output=True, check=True)
             if b'ninja: no work to do.' not in p.stdout and b'samu: nothing to do' not in p.stdout:
                 module_names = ' '.join(sorted(self._top_level_modules))
                 build_command = ' '.join(self._build_cmd)

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -304,10 +304,11 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
         env[MARKER] = os.pathsep.join((env.get(MARKER, ''), self._build_path))
 
         if self._verbose or bool(env.get(VERBOSE, '')):
+            # We do not want any output if there is no work to do. Code is adapted from:
+            # https://github.com/mesonbuild/meson/blob/a35d4d368a21f4b70afa3195da4d6292a649cb4c/mesonbuild/mtest.py#L1635-L1636
             dry_run_build_cmd = self._build_cmd + ['-n']
-            # We do not want any output if there is no work to do
             p = subprocess.run(dry_run_build_cmd, cwd=self._build_path, env=env, capture_output=True)
-            if b'no work to do' not in p.stdout:
+            if b'ninja: no work to do.' not in p.stdout and b'samu: nothing to do' not in p.stdout:
                 print('+ ' + ' '.join(self._build_cmd))
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env)
         else:

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -319,7 +319,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
         if self._verbose or bool(env.get(VERBOSE, '')):
             # We do not want any output if there is no work to do. Code is adapted from:
             # https://github.com/mesonbuild/meson/blob/a35d4d368a21f4b70afa3195da4d6292a649cb4c/mesonbuild/mtest.py#L1635-L1636
-            if self._build_cmd[0] == 'meson':
+            if sys.platform == 'win32':
                 # On Windows meson compile is used so to do a dry run you need
                 # --ninja-args
                 dry_run_build_cmd = self._build_cmd + ['--ninja-args=-n']

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -312,8 +312,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
                 module_names = ' '.join(sorted(self._top_level_modules))
                 build_command = ' '.join(self._build_cmd)
                 info_msg = (
-                    f'+ meson-python: building {module_names}\n'
-                    f'+ meson-python: executing {build_command}'
+                    f'meson-python: building {module_names} with {build_command}'
                 )
                 print(info_msg, flush=True)
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env)

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -309,7 +309,13 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             dry_run_build_cmd = self._build_cmd + ['-n']
             p = subprocess.run(dry_run_build_cmd, cwd=self._build_path, env=env, capture_output=True)
             if b'ninja: no work to do.' not in p.stdout and b'samu: nothing to do' not in p.stdout:
-                print('+ ' + ' '.join(self._build_cmd), flush=True)
+                module_names = ' '.join(sorted(self._top_level_modules))
+                build_command = ' '.join(self._build_cmd)
+                info_msg = (
+                    f"+ meson-python: building {module_names}\n"
+                    f'+ meson-python build command: {build_command}'
+                )
+                print(info_msg, flush=True)
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env)
         else:
             subprocess.run(self._build_cmd, cwd=self._build_path, env=env, stdout=subprocess.DEVNULL)

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -312,7 +312,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
                 module_names = ' '.join(sorted(self._top_level_modules))
                 build_command = ' '.join(self._build_cmd)
                 info_msg = (
-                    f"+ meson-python: building {module_names}\n"
+                    f'+ meson-python: building {module_names}\n'
                     f'+ meson-python build command: {build_command}'
                 )
                 print(info_msg, flush=True)

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -309,7 +309,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             if self._build_cmd[0] == 'meson':
                 # On Windows meson compile is used so to do a dry run you need
                 # --ninja-args
-                dry_run_build_cmd = self._build_cmd + ['--ninja-args="-n"']
+                dry_run_build_cmd = self._build_cmd + ['--ninja-args=-n']
             else:
                 dry_run_build_cmd = self._build_cmd + ['-n']
 
@@ -317,10 +317,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             if b'ninja: no work to do.' not in p.stdout and b'samu: nothing to do' not in p.stdout:
                 module_names = ' '.join(sorted(self._top_level_modules))
                 build_command = ' '.join(self._build_cmd)
-                info_msg = (
-                    f'meson-python: building {module_names} with {build_command}'
-                )
-                print(info_msg, flush=True)
+                print(f'meson-python: building {module_names} with {build_command!r}', flush=True)
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env)
         else:
             subprocess.run(self._build_cmd, cwd=self._build_path, env=env, stdout=subprocess.DEVNULL)

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -313,7 +313,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
                 build_command = ' '.join(self._build_cmd)
                 info_msg = (
                     f'+ meson-python: building {module_names}\n'
-                    f'+ meson-python build command: {build_command}'
+                    f'+ meson-python: executing {build_command}'
                 )
                 print(info_msg, flush=True)
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env)

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -306,7 +306,13 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
         if self._verbose or bool(env.get(VERBOSE, '')):
             # We do not want any output if there is no work to do. Code is adapted from:
             # https://github.com/mesonbuild/meson/blob/a35d4d368a21f4b70afa3195da4d6292a649cb4c/mesonbuild/mtest.py#L1635-L1636
-            dry_run_build_cmd = self._build_cmd + ['-n']
+            if self._build_cmd[0] == 'meson':
+                # On Windows meson compile is used so to do a dry run you need
+                # --ninja-args
+                dry_run_build_cmd = self._build_cmd + ['--ninja-args="-n"']
+            else:
+                dry_run_build_cmd = self._build_cmd + ['-n']
+
             p = subprocess.run(dry_run_build_cmd, cwd=self._build_path, env=env, capture_output=True)
             if b'ninja: no work to do.' not in p.stdout and b'samu: nothing to do' not in p.stdout:
                 module_names = ' '.join(sorted(self._top_level_modules))

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -13,7 +13,7 @@ import mesonpy
 
 from mesonpy import _editable
 
-from .test_wheel import EXT_SUFFIX, PLATFORM
+from .test_wheel import EXT_SUFFIX, tag
 
 
 def test_walk(package_complex):
@@ -192,7 +192,7 @@ def test_editble_reentrant(venv, editable_imports_itself_during_build):
         path.write_text(code)
 
 
-@pytest.mark.skipif(PLATFORM.startswith('muslinux'), reason='ninja -n segfaults on Alpine container')
+@pytest.mark.skipif(tag.platform.startswith('musllinux'), reason='ninja -n segfaults on Alpine container')
 def test_editable_verbose(venv, editable_complex, monkeypatch):
     monkeypatch.setenv('MESONPY_EDITABLE_VERBOSE', '1')
     venv.pip('install', os.fspath(editable_complex))

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -219,7 +219,7 @@ def test_editable_verbose(venv, editable_complex, monkeypatch):
         ]
         assert len(output_lines) == len(expected_pattern_list)
         for expected_pattern, output_line in zip(expected_pattern_list, output_lines):
-            assert re.search(expected_pattern, output_line), f"{expected_pattern} was not found in {output_line}"
+            assert re.search(expected_pattern, output_line), f'{expected_pattern} was not found in {output_line}'
 
         # New import without file changes should not show any output
         assert venv.python('-c', 'import complex') == ''

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -209,8 +209,7 @@ def test_editable_verbose(venv, editable_complex, monkeypatch):
     complex_package_dir = venv.python(
         '-c', 'import os; import complex; print(os.path.dirname(complex.__file__))').strip()
     cython_path = pathlib.Path(complex_package_dir).parent / 'test.pyx'
-    cython_content = cython_path.read_text()
-    cython_path.write_text(cython_content)
+    cython_path.touch()
     output = venv.python('-c', 'import complex').strip()
     assert output.startswith('meson-python: building complex with')
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -105,9 +105,9 @@ def test_mesonpy_meta_finder(package_complex, tmp_path, make_finder):
     finally:
         # remove finder from the meta path
         del sys.meta_path[0]
-        # unload complex module and all its submodules
+        # unload complex module and all its submodules to be able to run parametrized tests without side-effects
         for module in ['complex', 'complex.test', 'complex.namespace', 'complex.namespace.foo']:
-            del sys.modules[module]
+            sys.modules.pop(module, None)
 
 
 def test_mesonpy_traversable():

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -211,13 +211,12 @@ def test_editable_verbose(venv, editable_complex, monkeypatch):
         cython_path.write_text(cython_content + '\n')
         output = venv.python('-c', 'import complex').strip()
         output_lines = output.splitlines()
-        assert len(output_lines) > 2
-        # Only checking the first two output lines which meson-python controls.
+        assert len(output_lines) > 1
+        # Only checking the first output line which meson-python controls.
         # The rest of the output varies across platforms.
-        checked_output_lines = output_lines[:2]
+        checked_output_lines = output_lines[:1]
         expected_pattern_list =  [
-            'meson-python: building complex',
-            'meson-python: executing',
+            'meson-python: building complex with',
         ]
         assert len(checked_output_lines) == len(expected_pattern_list)
         for expected_pattern, output_line in zip(expected_pattern_list, checked_output_lines):

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -4,7 +4,6 @@
 
 import os
 import pathlib
-import re
 import sys
 
 import pytest
@@ -203,24 +202,14 @@ def test_editable_verbose(venv, editable_complex, monkeypatch):
     # Second import should have no output since the project has already been built
     assert venv.python('-c', 'import complex').strip() == ''
 
-    # Touch the pyx and make sure that the Compiling lines are seen
+    # Touch the pyx and make sure that the building info is seen
     complex_package_dir = venv.python(
         '-c', 'import os; import complex; print(os.path.dirname(complex.__file__))').strip()
     cython_path = pathlib.Path(complex_package_dir).parent / 'test.pyx'
     cython_content = cython_path.read_text()
     cython_path.write_text(cython_content)
     output = venv.python('-c', 'import complex').strip()
-    output_lines = output.splitlines()
-    assert len(output_lines) > 1
-    # Only checking the first output line which meson-python controls.
-    # The rest of the output varies across platforms.
-    checked_output_lines = output_lines[:1]
-    expected_pattern_list =  [
-        'meson-python: building complex with',
-    ]
-    assert len(checked_output_lines) == len(expected_pattern_list)
-    for expected_pattern, output_line in zip(expected_pattern_list, checked_output_lines):
-        assert re.search(expected_pattern, output_line), f'{expected_pattern} was not found in {output_line}'
+    assert output.startswith('meson-python: building complex with')
 
     # Another import without file changes should not show any output
     assert venv.python('-c', 'import complex') == ''

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -104,6 +104,7 @@ def test_mesonpy_meta_finder(package_complex, tmp_path, make_finder):
     finally:
         # remove finder from the meta path
         del sys.meta_path[0]
+        # unload complex module and all its submodules
         for module in ['complex', 'complex.test', 'complex.namespace', 'complex.namespace.foo']:
             del sys.modules[module]
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -71,7 +71,8 @@ def test_mesonpy_meta_finder(package_complex, tmp_path, make_finder):
     mesonpy.Project(package_complex, tmp_path)
 
     # point the meta finder to the build directory
-    finder = make_finder({'complex'}, os.fspath(tmp_path), ['ninja'])
+    build_cmd = ['meson', 'compile'] if sys.platform == 'win32' else ['ninja']
+    finder = make_finder({'complex'}, os.fspath(tmp_path), build_cmd)
 
     # check repr
     assert repr(finder) == f'MesonpyMetaFinder({str(tmp_path)!r})'

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -207,7 +207,9 @@ def test_editable_verbose(venv, editable_complex, monkeypatch):
     try:
         cython_path.write_text(cython_content + '\n')
         output = venv.python('-c', 'import complex').strip()
-        output_lines = output.splitlines()
+        # Need to filter some warning on OSX like
+        # 'ld: warning: -undefined dynamic_lookup may not work with chained fixups'
+        output_lines = [line for line in output.splitlines() if 'warning' not in line]
         expected_pattern_list =  [
             'meson-python: building complex',
             'meson-python build command:.+(ninja|samu)',

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -196,7 +196,7 @@ def test_editble_reentrant(venv, editable_imports_itself_during_build):
 
 @pytest.mark.skipif(tag.platform.startswith('musllinux'), reason='ninja -n segfaults on Alpine container')
 def test_editable_verbose(venv, editable_complex, monkeypatch):
-    monkeypatch.setenv('MESONPY_EDITABLE_VERBOSE', '1')
+    monkeypatch.setenv(_editable.VERBOSE, '1')
     venv.pip('install', os.fspath(editable_complex))
 
     # First import to make sure that the project is built

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -4,6 +4,7 @@
 
 import os
 import pathlib
+import re
 import sys
 
 import pytest
@@ -199,17 +200,24 @@ def test_editable_verbose(venv, editable_complex, monkeypatch):
     assert venv.python('-c', 'import complex').strip() == ''
 
     # Add empty line a pyx, make sure that the Compiling lines are seen
-    complex_package_dir = venv.python('-c', 'import os; import complex; print(os.path.dirname(complex.__file__))').strip()
+    complex_package_dir = venv.python(
+        '-c', 'import os; import complex; print(os.path.dirname(complex.__file__))').strip()
     cython_path = pathlib.Path(complex_package_dir).parent / 'test.pyx'
     cython_content = cython_path.read_text()
     try:
         cython_path.write_text(cython_content + '\n')
         output = venv.python('-c', 'import complex').strip()
         output_lines = output.splitlines()
-        expected_text_list =  ['ninja', 'Compiling Cython source', 'Compiling C object', 'Linking target']
-        assert len(output_lines) == len(expected_text_list)
-        for expected_text, output_line in zip(expected_text_list, output_lines):
-            assert expected_text in output_line
+        expected_pattern_list =  [
+            'meson-python: building complex',
+            'meson-python build command:.+(ninja|samu)',
+            'Compiling Cython source',
+            'Compiling C object',
+            'Linking target'
+        ]
+        assert len(output_lines) == len(expected_pattern_list)
+        for expected_pattern, output_line in zip(expected_pattern_list, output_lines):
+            assert re.search(expected_pattern, output_line), f"{expected_pattern} was not found in {output_line}"
 
         # New import without file changes should not show any output
         assert venv.python('-c', 'import complex') == ''

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -13,7 +13,7 @@ import mesonpy
 
 from mesonpy import _editable
 
-from .test_wheel import EXT_SUFFIX
+from .test_wheel import EXT_SUFFIX, PLATFORM
 
 
 def test_walk(package_complex):
@@ -192,6 +192,7 @@ def test_editble_reentrant(venv, editable_imports_itself_during_build):
         path.write_text(code)
 
 
+@pytest.mark.skipif(PLATFORM.startswith('muslinux'), reason='ninja -n segfaults on Alpine container')
 def test_editable_verbose(venv, editable_complex, monkeypatch):
     monkeypatch.setenv('MESONPY_EDITABLE_VERBOSE', '1')
     venv.pip('install', os.fspath(editable_complex))


### PR DESCRIPTION
### Why the current behaviour is problematic

The "ninja: no work to do" output can be confusing as noted for example by @ogrisel in https://github.com/scikit-learn/scikit-learn/pull/28040#issuecomment-1886676007. @eli-schwartz mentioned that it could potentially be changed in meson-python https://github.com/scikit-learn/scikit-learn/pull/28040#issuecomment-1888470251.

Personally, when working on scikit-learn code, I find it reassuring to see some output if the sklearn import takes a while and get the feed-back that some compilation is happening. In the case when there is nothing to do I would rather have nothing printed. One thing I realised recently is that the "no work to do" output can be printed multiple times if you use subprocesses (makes complete sense since sklearn is imported in each subprocess). This can happen easily in scikit-learn for example with this snippet.

```py
# /tmp/test.py
from sklearn.linear_model import LogisticRegression
from sklearn.datasets import make_classification
from sklearn.model_selection import cross_val_score

model = LogisticRegression()
X, y = make_classification()

print(cross_val_score(model, X, y, n_jobs=4))
```

Output is:
```
❯ python /tmp/test.py
+ /home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja
ninja: no work to do.
+ /home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja
+ /home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja
+ /home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja
+ /home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja
ninja: no work to do.
ninja: no work to do.
ninja: no work to do.
ninja: no work to do.
[1.   0.85 0.9  0.95 0.95]
```

### Current implementation

The simplest thing I could find was to first execute the `ninja` command in dry-run mode and to check if "no work to do" is in the captured stdout. This may be a bit brittle in case the ninja output changes. Maybe there is a better way to check with `ninja` that there is no work to do?

There does not seem to be any test right now for the editable verbose behavior, but I can try to add some if you think this is worth it.

### Alternative implementation

If you think the overhead of having a `ninja` dry-run command is too much overhead, one possible alternative implementation would be to capture `stdout` with `p = subprocess.Popen(..., stdout=subprocess.PIPE)` and look at the first two lines of output. In my experience, this kind of manipulation are always more complicated than you would hope, but maybe I have been doing it wrong all this time ...

The kind of complications I have in mind:
- `p.stdout.read` is blocking so in the case that there is no output for some reason, it will wait for ever. Maybe we know there will always be some output with the `ninja` command. You can also put you can use `fcntl` to put stdout in non-blocking mode.
- displaying the captured stdout live (i.e. without waiting for the command to finish) is also always more complicated than you would hope:
  + decide whether to read line by line, a few lines, a number of bytes
  + decide whether to sleep between two reads (I have seen some cases where not sleeping had a high CPU usage)
  + you also need to remember to redisplay all the remaining stdout once the command finishes otherwise you miss some stdout.