### PR TITLE
Extend documentation on environment variables

### DIFF
--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -8,6 +8,36 @@
 Environment variables
 *********************
 
+Environment variables can be used to influence ``meson-python``'s behavior, as
+well as the behavior of Meson and other tools that may be used during the
+build. This page lists all the environment variables directly used by
+``meson-python``.
+
+Meson recommends using command line arguments instead of environment variables,
+but does support a number of environment variables for compatibility with other
+build systems:
+
+- `Compiler and linker flag variables <https://mesonbuild.com/Reference-tables.html#compiler-and-linker-flag-environment-variables>`__
+- `Compiler and linker selection variables <https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables>`__
+
+Other environment variables may influence how other tools used during the setup
+or build steps operate. For example, ``pkg-config`` supports
+``PKG_CONFIG_PATH`` which influences the search path for ``.pc`` files
+describing the available dependencies.
+
+.. warning::
+
+    Conda sets a number of environment variables during environment activation
+    for compiler/linker selection (``CC``, ``CXX``, ``FC``, ``LD``) and
+    compile/link flags (``CFLAGS``, ``CXXFLAGS``, ``FFLAGS``, ``LDFLAGS``) when
+    compilers are installed in a conda environment. This may have unexpected
+    side effects (see for example the note in
+    :ref:`how-to-guides-debug-builds`).
+
+
+Environment variables used by meson-python
+==========================================
+
 .. envvar:: ARCHFLAGS
 
    This environmental variable is used for supporting architecture cross

--- a/docs/reference/pyproject-settings.rst
+++ b/docs/reference/pyproject-settings.rst
@@ -31,7 +31,7 @@ use them and examples.
    A string specifying the ``meson`` executable or script to use. If it is a
    path to an existing file with a name ending in ``.py``, it will be invoked
    as a Python script using the same Python interpreter that is used to run
-   ``meson-python`` itself. It can be overrridden by the :envvar:`MESON`
+   ``meson-python`` itself. It can be overridden by the :envvar:`MESON`
    environment variable.
 
 .. option:: tool.meson-python.args.dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ test = [
   'typing-extensions >= 3.7.4; python_version < "3.11"',
 ]
 docs = [
-  'furo >= 2021.08.31',
-  'sphinx ~= 4.0',
+  'furo >= 2023.5.20',
+  'sphinx ~= 6.2',
   'sphinx-copybutton >= 0.5.0',
   'sphinx-design >= 0.1.0',
   'sphinxext-opengraph >= 0.7.0',


### PR DESCRIPTION
- cross link to the tables of compiler/linker flags in the Meson docs
- mention `PKG_CONFIG_PATH`
- add a warning about Conda's habit of injecting env vars also on the environment variables reference page

Closes gh-460