### PR TITLE
CI: install real ninja in Alpine Linux image

### DIFF
--- a/ci/alpine-3.docker
+++ b/ci/alpine-3.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20240204
+# 20240305
 FROM alpine:3
-RUN apk add --no-cache python3-dev py3-pip build-base ninja git patchelf
+RUN apk add --no-cache python3-dev py3-pip build-base ninja-is-really-ninja git patchelf


### PR DESCRIPTION
Alpine Linux replaces ninja with samurai in the default installation. Meson and meson-python work with either, however, the version of samurai available in Alpine Linux segfaults when invoked with the -n options. Having to deal with this in the test suite is a pain. Switch to proper ninja.