### PR TITLE
CI: add Meson 1.3 to the old meson releases we test with

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,9 @@ jobs:
           - os: ubuntu
             python: '3.12'
             meson: '~=1.2.3'
+          - os: ubuntu
+            python: '3.12'
+            meson: '~=1.3'
           # Test with Meson master branch.
           - os: ubuntu
             python: '3.12'


### PR DESCRIPTION
Meson 1.4 has been released, thus all tests normally run with it.