### PR TITLE
BLD: add missing dependency on `packaging`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ backend-path = ['.']
 requires = [
   'meson >= 0.63.3; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
+  'packaging >= 19.0',
   'pyproject-metadata >= 0.7.1',
   'tomli >= 1.0.0; python_version < "3.11"',
 ]
@@ -34,6 +35,7 @@ classifiers = [
 dependencies = [
   'meson >= 0.63.3; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
+  'packaging >= 19.0',
   'pyproject-metadata >= 0.7.1',
   'tomli >= 1.0.0; python_version < "3.11"',
 ]


### PR DESCRIPTION
We were relying on `pyproject-metadata` adding a `packaging` dependency implicitly. We use it directly though, so should add it in our own metadata. We have no particular version requirements beyond what is needed by `pyproject-metadata`, so we add the same >=19.0 constraint.

This follows up on https://github.com/mesonbuild/meson-python/pull/612#issuecomment-2060528062