### PR TITLE
DOC: add docs on using the `build-dir` config setting

### DIFF
--- a/docs/reference/config-settings.rst
+++ b/docs/reference/config-settings.rst
@@ -23,10 +23,6 @@ them.
    exists and contains a valid Meson build directory setup, the
    project will be reconfigured using ``meson setup --reconfigure``.
 
-   The same build directory can be used by subsequent invocations of
-   ``meson-python``. This avoids having to rebuild the whole project
-   when testing changes during development.
-
    For backward compatibility reasons, the alternative ``builddir``
    spelling is also accepted.
 


### PR DESCRIPTION
Closes gh-540

Also touches on gh-246, which is a common enough hiccup that it's useful to explicitly show dealing with `meson-log.txt` in CI.