### PR TITLE
Disable abi3 wheel tag for PyPy

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -406,22 +406,23 @@ class _WheelBuilder():
 
     @cached_property
     def _stable_abi(self) -> Optional[str]:
-        if self._limited_api:
-            # PyPy does not use a special extension module filename
-            # suffix for modules targeting the stable API.
-            if '__pypy__' not in sys.builtin_module_names:
-                # Verify stable ABI compatibility: examine files installed
-                # in {platlib} that look like extension modules, and raise
-                # an exception if any of them has a Python version
-                # specific extension filename suffix ABI tag.
-                for path, _ in self._manifest['platlib']:
-                    match = _EXTENSION_SUFFIX_REGEX.match(path.name)
-                    if match:
-                        abi = match.group('abi')
-                        if abi is not None and abi != 'abi3':
-                            raise BuildError(
-                                f'The package declares compatibility with Python limited API but extension '
-                                f'module {os.fspath(path)!r} is tagged for a specific Python version.')
+        # PyPy supports the limited API but does not provide a stable
+        # ABI, therefore extension modules using the limited API do
+        # not use the stable ABI filename suffix and wheels should not
+        # be tagged with the abi3 tag.
+        if self._limited_api and '__pypy__' not in sys.builtin_module_names:
+            # Verify stable ABI compatibility: examine files installed
+            # in {platlib} that look like extension modules, and raise
+            # an exception if any of them has a Python version
+            # specific extension filename suffix ABI tag.
+            for path, _ in self._manifest['platlib']:
+                match = _EXTENSION_SUFFIX_REGEX.match(path.name)
+                if match:
+                    abi = match.group('abi')
+                    if abi is not None and abi != 'abi3':
+                        raise BuildError(
+                            f'The package declares compatibility with Python limited API but extension '
+                            f'module {os.fspath(path)!r} is tagged for a specific Python version.')
             return 'abi3'
         return None
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -103,11 +103,13 @@ def test_tag_stable_abi():
     builder = wheel_builder_test_factory({
         'platlib': [f'extension{ABI3SUFFIX}'],
     }, limited_api=True)
-    assert str(builder.tag) == f'{INTERPRETER}-abi3-{PLATFORM}'
+    # PyPy does not support the stable ABI.
+    abi = 'abi3' if '__pypy__' not in sys.builtin_module_names else ABI
+    assert str(builder.tag) == f'{INTERPRETER}-{abi}-{PLATFORM}'
 
 
 @pytest.mark.xfail(sys.version_info < (3, 8) and sys.platform == 'win32', reason='Extension modules suffix without ABI tags')
-@pytest.mark.xfail('__pypy__' in sys.builtin_module_names, reason='PyPy does not use special modules suffix for stable ABI')
+@pytest.mark.xfail('__pypy__' in sys.builtin_module_names, reason='PyPy does not support the stable ABI')
 def test_tag_mixed_abi():
     builder = wheel_builder_test_factory({
         'platlib': [f'extension{ABI3SUFFIX}', f'another{SUFFIX}'],

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -290,6 +290,7 @@ def test_skip_subprojects(package_subproject, tmp_path, arg):
 # Requires Meson 1.3.0, see https://github.com/mesonbuild/meson/pull/11745.
 @pytest.mark.skipif(MESON_VERSION < (1, 2, 99), reason='Meson version too old')
 @pytest.mark.skipif(NOGIL_BUILD, reason='Free-threaded CPython does not support the limited API')
+@pytest.mark.xfail('__pypy__' in sys.builtin_module_names, reason='PyPy does not support the abi3 platform tag for wheels')
 def test_limited_api(wheel_limited_api):
     artifact = wheel.wheelfile.WheelFile(wheel_limited_api)
     name = artifact.parsed_filename


### PR DESCRIPTION
Pip does not support installing PyPy wheels with the abi3 tag. If you build a wheel for PyPy and set the ABI tag to `abi3`, pip will not be able to install it.

```
$ docker run --rm -it quay.io/pypa/manylinux2014_x86_64
[root@cd7b2d465170 /]# /opt/python/pp39-pypy39_pp73/bin/python
Python 3.9.19 (a2113ea87262, Apr 21 2024, 05:40:24)
[PyPy 7.3.16 with GCC 10.2.1 20210130 (Red Hat 10.2.1-11)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>> from pip._internal.utils.compatibility_tags import get_supported
>>>> for tag in get_supported():
....     print(tag)
....
pp39-pypy39_pp73-manylinux_2_17_x86_64
pp39-pypy39_pp73-manylinux2014_x86_64
```

Full output:

<details>

```
>>>> from pip._internal.utils.compatibility_tags import get_supported
>>>> for tag in get_supported():
....     print(tag)
....
pp39-pypy39_pp73-manylinux_2_17_x86_64
pp39-pypy39_pp73-manylinux2014_x86_64
pp39-pypy39_pp73-manylinux_2_16_x86_64
pp39-pypy39_pp73-manylinux_2_15_x86_64
pp39-pypy39_pp73-manylinux_2_14_x86_64
pp39-pypy39_pp73-manylinux_2_13_x86_64
pp39-pypy39_pp73-manylinux_2_12_x86_64
pp39-pypy39_pp73-manylinux2010_x86_64
pp39-pypy39_pp73-manylinux_2_11_x86_64
pp39-pypy39_pp73-manylinux_2_10_x86_64
pp39-pypy39_pp73-manylinux_2_9_x86_64
pp39-pypy39_pp73-manylinux_2_8_x86_64
pp39-pypy39_pp73-manylinux_2_7_x86_64
pp39-pypy39_pp73-manylinux_2_6_x86_64
pp39-pypy39_pp73-manylinux_2_5_x86_64
pp39-pypy39_pp73-manylinux1_x86_64
pp39-pypy39_pp73-linux_x86_64
pp39-none-manylinux_2_17_x86_64
pp39-none-manylinux2014_x86_64
pp39-none-manylinux_2_16_x86_64
pp39-none-manylinux_2_15_x86_64
pp39-none-manylinux_2_14_x86_64
pp39-none-manylinux_2_13_x86_64
pp39-none-manylinux_2_12_x86_64
pp39-none-manylinux2010_x86_64
pp39-none-manylinux_2_11_x86_64
pp39-none-manylinux_2_10_x86_64
pp39-none-manylinux_2_9_x86_64
pp39-none-manylinux_2_8_x86_64
pp39-none-manylinux_2_7_x86_64
pp39-none-manylinux_2_6_x86_64
pp39-none-manylinux_2_5_x86_64
pp39-none-manylinux1_x86_64
pp39-none-linux_x86_64
py39-none-manylinux_2_17_x86_64
py39-none-manylinux2014_x86_64
py39-none-manylinux_2_16_x86_64
py39-none-manylinux_2_15_x86_64
py39-none-manylinux_2_14_x86_64
py39-none-manylinux_2_13_x86_64
py39-none-manylinux_2_12_x86_64
py39-none-manylinux2010_x86_64
py39-none-manylinux_2_11_x86_64
py39-none-manylinux_2_10_x86_64
py39-none-manylinux_2_9_x86_64
py39-none-manylinux_2_8_x86_64
py39-none-manylinux_2_7_x86_64
py39-none-manylinux_2_6_x86_64
py39-none-manylinux_2_5_x86_64
py39-none-manylinux1_x86_64
py39-none-linux_x86_64
py3-none-manylinux_2_17_x86_64
py3-none-manylinux2014_x86_64
py3-none-manylinux_2_16_x86_64
py3-none-manylinux_2_15_x86_64
py3-none-manylinux_2_14_x86_64
py3-none-manylinux_2_13_x86_64
py3-none-manylinux_2_12_x86_64
py3-none-manylinux2010_x86_64
py3-none-manylinux_2_11_x86_64
py3-none-manylinux_2_10_x86_64
py3-none-manylinux_2_9_x86_64
py3-none-manylinux_2_8_x86_64
py3-none-manylinux_2_7_x86_64
py3-none-manylinux_2_6_x86_64
py3-none-manylinux_2_5_x86_64
py3-none-manylinux1_x86_64
py3-none-linux_x86_64
py38-none-manylinux_2_17_x86_64
py38-none-manylinux2014_x86_64
py38-none-manylinux_2_16_x86_64
py38-none-manylinux_2_15_x86_64
py38-none-manylinux_2_14_x86_64
py38-none-manylinux_2_13_x86_64
py38-none-manylinux_2_12_x86_64
py38-none-manylinux2010_x86_64
py38-none-manylinux_2_11_x86_64
py38-none-manylinux_2_10_x86_64
py38-none-manylinux_2_9_x86_64
py38-none-manylinux_2_8_x86_64
py38-none-manylinux_2_7_x86_64
py38-none-manylinux_2_6_x86_64
py38-none-manylinux_2_5_x86_64
py38-none-manylinux1_x86_64
py38-none-linux_x86_64
py37-none-manylinux_2_17_x86_64
py37-none-manylinux2014_x86_64
py37-none-manylinux_2_16_x86_64
py37-none-manylinux_2_15_x86_64
py37-none-manylinux_2_14_x86_64
py37-none-manylinux_2_13_x86_64
py37-none-manylinux_2_12_x86_64
py37-none-manylinux2010_x86_64
py37-none-manylinux_2_11_x86_64
py37-none-manylinux_2_10_x86_64
py37-none-manylinux_2_9_x86_64
py37-none-manylinux_2_8_x86_64
py37-none-manylinux_2_7_x86_64
py37-none-manylinux_2_6_x86_64
py37-none-manylinux_2_5_x86_64
py37-none-manylinux1_x86_64
py37-none-linux_x86_64
py36-none-manylinux_2_17_x86_64
py36-none-manylinux2014_x86_64
py36-none-manylinux_2_16_x86_64
py36-none-manylinux_2_15_x86_64
py36-none-manylinux_2_14_x86_64
py36-none-manylinux_2_13_x86_64
py36-none-manylinux_2_12_x86_64
py36-none-manylinux2010_x86_64
py36-none-manylinux_2_11_x86_64
py36-none-manylinux_2_10_x86_64
py36-none-manylinux_2_9_x86_64
py36-none-manylinux_2_8_x86_64
py36-none-manylinux_2_7_x86_64
py36-none-manylinux_2_6_x86_64
py36-none-manylinux_2_5_x86_64
py36-none-manylinux1_x86_64
py36-none-linux_x86_64
py35-none-manylinux_2_17_x86_64
py35-none-manylinux2014_x86_64
py35-none-manylinux_2_16_x86_64
py35-none-manylinux_2_15_x86_64
py35-none-manylinux_2_14_x86_64
py35-none-manylinux_2_13_x86_64
py35-none-manylinux_2_12_x86_64
py35-none-manylinux2010_x86_64
py35-none-manylinux_2_11_x86_64
py35-none-manylinux_2_10_x86_64
py35-none-manylinux_2_9_x86_64
py35-none-manylinux_2_8_x86_64
py35-none-manylinux_2_7_x86_64
py35-none-manylinux_2_6_x86_64
py35-none-manylinux_2_5_x86_64
py35-none-manylinux1_x86_64
py35-none-linux_x86_64
py34-none-manylinux_2_17_x86_64
py34-none-manylinux2014_x86_64
py34-none-manylinux_2_16_x86_64
py34-none-manylinux_2_15_x86_64
py34-none-manylinux_2_14_x86_64
py34-none-manylinux_2_13_x86_64
py34-none-manylinux_2_12_x86_64
py34-none-manylinux2010_x86_64
py34-none-manylinux_2_11_x86_64
py34-none-manylinux_2_10_x86_64
py34-none-manylinux_2_9_x86_64
py34-none-manylinux_2_8_x86_64
py34-none-manylinux_2_7_x86_64
py34-none-manylinux_2_6_x86_64
py34-none-manylinux_2_5_x86_64
py34-none-manylinux1_x86_64
py34-none-linux_x86_64
py33-none-manylinux_2_17_x86_64
py33-none-manylinux2014_x86_64
py33-none-manylinux_2_16_x86_64
py33-none-manylinux_2_15_x86_64
py33-none-manylinux_2_14_x86_64
py33-none-manylinux_2_13_x86_64
py33-none-manylinux_2_12_x86_64
py33-none-manylinux2010_x86_64
py33-none-manylinux_2_11_x86_64
py33-none-manylinux_2_10_x86_64
py33-none-manylinux_2_9_x86_64
py33-none-manylinux_2_8_x86_64
py33-none-manylinux_2_7_x86_64
py33-none-manylinux_2_6_x86_64
py33-none-manylinux_2_5_x86_64
py33-none-manylinux1_x86_64
py33-none-linux_x86_64
py32-none-manylinux_2_17_x86_64
py32-none-manylinux2014_x86_64
py32-none-manylinux_2_16_x86_64
py32-none-manylinux_2_15_x86_64
py32-none-manylinux_2_14_x86_64
py32-none-manylinux_2_13_x86_64
py32-none-manylinux_2_12_x86_64
py32-none-manylinux2010_x86_64
py32-none-manylinux_2_11_x86_64
py32-none-manylinux_2_10_x86_64
py32-none-manylinux_2_9_x86_64
py32-none-manylinux_2_8_x86_64
py32-none-manylinux_2_7_x86_64
py32-none-manylinux_2_6_x86_64
py32-none-manylinux_2_5_x86_64
py32-none-manylinux1_x86_64
py32-none-linux_x86_64
py31-none-manylinux_2_17_x86_64
py31-none-manylinux2014_x86_64
py31-none-manylinux_2_16_x86_64
py31-none-manylinux_2_15_x86_64
py31-none-manylinux_2_14_x86_64
py31-none-manylinux_2_13_x86_64
py31-none-manylinux_2_12_x86_64
py31-none-manylinux2010_x86_64
py31-none-manylinux_2_11_x86_64
py31-none-manylinux_2_10_x86_64
py31-none-manylinux_2_9_x86_64
py31-none-manylinux_2_8_x86_64
py31-none-manylinux_2_7_x86_64
py31-none-manylinux_2_6_x86_64
py31-none-manylinux_2_5_x86_64
py31-none-manylinux1_x86_64
py31-none-linux_x86_64
py30-none-manylinux_2_17_x86_64
py30-none-manylinux2014_x86_64
py30-none-manylinux_2_16_x86_64
py30-none-manylinux_2_15_x86_64
py30-none-manylinux_2_14_x86_64
py30-none-manylinux_2_13_x86_64
py30-none-manylinux_2_12_x86_64
py30-none-manylinux2010_x86_64
py30-none-manylinux_2_11_x86_64
py30-none-manylinux_2_10_x86_64
py30-none-manylinux_2_9_x86_64
py30-none-manylinux_2_8_x86_64
py30-none-manylinux_2_7_x86_64
py30-none-manylinux_2_6_x86_64
py30-none-manylinux_2_5_x86_64
py30-none-manylinux1_x86_64
py30-none-linux_x86_64
pp39-none-any
py39-none-any
py3-none-any
py38-none-any
py37-none-any
py36-none-any
py35-none-any
py34-none-any
py33-none-any
py32-none-any
py31-none-any
py30-none-any
```

</details>