### PR TITLE
DOC: add a brief explanation of build isolation to the tutorial

### DIFF
--- a/docs/tutorials/introduction.rst
+++ b/docs/tutorials/introduction.rst
@@ -255,6 +255,19 @@ If the build succeeded, you'll have the binary artifacts in the ``dist`` folder.
    easier, we recommend checking out the cibuildwheel_ project, which allows you
    to automate it.
 
+Build isolation
+```````````````
+
+Building with ``python -m build`` or with ``pip`` uses build isolation by
+default. I.e., the build frontend creates a new, temporary virtual environment
+with all build dependencies before calling ``meson-python`` to build a wheel.
+
+If you disable build isolation, you are responsible for ensuring that
+``meson-python`` and all other build dependencies for the package are installed
+already in the Python environment. Note that if you use a virtual environment
+to build in, it must be activated (otherwise ``meson`` or another executable
+may not be found).
+
 
 Distributing the project
 ------------------------


### PR DESCRIPTION
Build isolation is a regular cause of confusion for many users, so a brief explanation can't hurt.

Also add a very brief note that the build venv must be activated - the `venv` docs are confusing here, as gh-630 shows. Closes gh-630