### PR TITLE
Editable install: raise ImportError when rebuilding fails

### DIFF
--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -255,6 +255,7 @@ def collect(install_plan: Dict[str, Dict[str, Any]]) -> Node:
                     tree[path.parts[1:]] = src
     return tree
 
+
 def find_spec(fullname: str, tree: Node) -> Optional[importlib.machinery.ModuleSpec]:
     namespace = False
     parts = fullname.split('.')

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -75,6 +75,8 @@ def test_collect(package_complex):
     assert tree['complex']['more']['__init__.py'] == os.path.join(root, 'complex', 'more', '__init__.py')
 
 
+@pytest.mark.skipif(NOGIL_BUILD and CYTHON_VERSION < (3, 1, 0),
+                    reason='Cython version too old, no free-threaded CPython support')
 def test_mesonpy_meta_finder(package_complex, tmp_path):
     # build a package in a temporary directory
     project = mesonpy.Project(package_complex, tmp_path)
@@ -208,6 +210,8 @@ def test_editble_reentrant(venv, editable_imports_itself_during_build):
         path.write_text(code)
 
 
+@pytest.mark.skipif(NOGIL_BUILD and CYTHON_VERSION < (3, 1, 0),
+                    reason='Cython version too old, no free-threaded CPython support')
 def test_editable_pkgutils_walk_packages(package_complex, tmp_path):
     # build a package in a temporary directory
     project = mesonpy.Project(package_complex, tmp_path)

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -77,10 +77,10 @@ def test_collect(package_complex):
 
 def test_mesonpy_meta_finder(package_complex, tmp_path):
     # build a package in a temporary directory
-    mesonpy.Project(package_complex, tmp_path)
+    project = mesonpy.Project(package_complex, tmp_path)
 
     # point the meta finder to the build directory
-    finder = _editable.MesonpyMetaFinder('complex', {'complex'}, os.fspath(tmp_path), ['ninja'])
+    finder = _editable.MesonpyMetaFinder('complex', {'complex'}, os.fspath(tmp_path), project._build_command, True)
 
     # check repr
     assert repr(finder) == f'MesonpyMetaFinder(\'complex\', {str(tmp_path)!r})'
@@ -141,10 +141,10 @@ def test_mesonpy_traversable():
 def test_resources(tmp_path):
     # build a package in a temporary directory
     package_path = pathlib.Path(__file__).parent / 'packages' / 'simple'
-    mesonpy.Project(package_path, tmp_path)
+    project = mesonpy.Project(package_path, tmp_path)
 
     # point the meta finder to the build directory
-    finder = _editable.MesonpyMetaFinder('simple', {'simple'}, os.fspath(tmp_path), ['ninja'])
+    finder = _editable.MesonpyMetaFinder('simple', {'simple'}, os.fspath(tmp_path), project._build_command, True)
 
     # verify that we can look up resources
     spec = finder.find_spec('simple')
@@ -160,10 +160,10 @@ def test_resources(tmp_path):
 def test_importlib_resources(tmp_path):
     # build a package in a temporary directory
     package_path = pathlib.Path(__file__).parent / 'packages' / 'simple'
-    mesonpy.Project(package_path, tmp_path)
+    project = mesonpy.Project(package_path, tmp_path)
 
     # point the meta finder to the build directory
-    finder = _editable.MesonpyMetaFinder('simple', {'simple'}, os.fspath(tmp_path), ['ninja'])
+    finder = _editable.MesonpyMetaFinder('simple', {'simple'}, os.fspath(tmp_path), project._build_command, True)
 
     try:
         # install the finder in the meta path
@@ -210,9 +210,9 @@ def test_editble_reentrant(venv, editable_imports_itself_during_build):
 
 def test_editable_pkgutils_walk_packages(package_complex, tmp_path):
     # build a package in a temporary directory
-    mesonpy.Project(package_complex, tmp_path)
+    project = mesonpy.Project(package_complex, tmp_path)
 
-    finder = _editable.MesonpyMetaFinder('complex', {'complex'}, os.fspath(tmp_path), ['ninja'])
+    finder = _editable.MesonpyMetaFinder('complex', {'complex'}, os.fspath(tmp_path), project._build_command, True)
 
     try:
         # install editable hooks
@@ -244,8 +244,8 @@ def test_editable_pkgutils_walk_packages(package_complex, tmp_path):
 
 
 def test_custom_target_install_dir(package_custom_target_dir, tmp_path):
-    mesonpy.Project(package_custom_target_dir, tmp_path)
-    finder = _editable.MesonpyMetaFinder('package', {'package'}, os.fspath(tmp_path), ['ninja'])
+    project = mesonpy.Project(package_custom_target_dir, tmp_path)
+    finder = _editable.MesonpyMetaFinder('package', {'package'}, os.fspath(tmp_path), project._build_command, True)
     try:
         sys.meta_path.insert(0, finder)
         import package.generated.one


### PR DESCRIPTION
When using meson editable install, this can be very suprising that there is no obvious error when recompilation fails.

One use case I bumped into:
1. I modify a scikit-learn cython file and introduce a compilation error
2. I run my scikit-learn test `pytest sklearn/.../test_bla.py` that imports scikit-learn and should recompile when needed

What happens:
The test run so I thought everything was fine, but actually the recompilation failed and I did not notice because `pytest` captures the output. If I had done `pytest -s` and looked carefully at the output I may have noticed

What I would expect:
There is an explicit error that tells me that recompilation failed.


With the current change, the tests run fine locally but there may be a side-effect I have not thought of?

This is how the output currently looks:
```
❯ pytest sklearn/tests/test_isotonic.py   
meson-python: building scikit-learn: /home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja
[1/3] Compiling Cython source /home/lesteve/dev/scikit-learn/sklearn/_isotonic.pyx
FAILED: sklearn/_isotonic.cpython-312-x86_64-linux-gnu.so.p/sklearn/_isotonic.pyx.c 
cython -M --fast-fail -3 '-X language_level=3' '-X boundscheck=False' '-X wraparound=False' '-X initializedcheck=False' '-X nonecheck=False' '-X cdivision=True' '-X profile=False' --include-dir /home/lesteve/dev/scikit-learn/build/cp312 /home/lesteve/dev/scikit-learn/sklearn/_isotonic.pyx -o sklearn/_isotonic.cpython-312-x86_64-linux-gnu.so.p/sklearn/_isotonic.pyx.c

Error compiling Cython file:
------------------------------------------------------------
...
# Author: Nelle Varoquaux, Andrew Tulloch, Antony Lee

# Uses the pool adjacent violators algorithm (PAVA), with the
# enhancement of searching for the longest decreasing subsequence to
# pool at each step.
asdf
^
------------------------------------------------------------

/home/lesteve/dev/scikit-learn/sklearn/_isotonic.pyx:6:0: undeclared name not builtin: asdf
ninja: build stopped: subcommand failed.
ImportError while loading conftest '/home/lesteve/dev/scikit-learn/sklearn/conftest.py'.
../../micromamba/envs/scikit-learn-dev/lib/python3.12/site-packages/_scikit_learn_editable_loader.py:309: in find_spec
    tree = self._rebuild()
../../micromamba/envs/scikit-learn-dev/lib/python3.12/site-packages/_scikit_learn_editable_loader.py:340: in _rebuild
    subprocess.run(self._build_cmd, cwd=self._build_path, env=env, check=True)
../../micromamba/envs/scikit-learn-dev/lib/python3.12/subprocess.py:571: in run
    raise CalledProcessError(retcode, process.args,
E   subprocess.CalledProcessError: Command '['/home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja']' returned non-zero exit status 1.
```

I will look at adding a test once I get some feed-back that this is something that looks reasonable.