### PR TITLE
MAINT: pre-commit autoupdate 2024-07-31

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-ast
   - id: check-builtin-literals
@@ -21,12 +21,12 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.5
+  rev: v0.5.5
   hooks:
   - id: ruff
     args: [--fix, --show-fixes, --output-format, grouped]
 - repo: https://github.com/fsfe/reuse-tool
-  rev: v2.1.0
+  rev: v4.0.3
   hooks:
   - id: reuse
     name: add SPDX headers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,10 +77,10 @@ strict = true
 
 [tool.ruff]
 line-length = 127
-extend-ignore = [
+lint.extend-ignore = [
   'B019',
 ]
-select = [
+lint.select = [
   'B',       # flake8-bugbear
   'C4',      # flake8-comprehensions
   'E',       # pycodestyle

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -284,7 +284,7 @@ def test_editable_rebuild(package_purelib_and_platlib, tmp_path, verbose, args):
             # Importing again should result in no output.
             stdout = io.StringIO()
             with redirect_stdout(stdout):
-                import pure  # noqa: F401, F811
+                import pure  # noqa: F401
             assert stdout.getvalue() == ''
 
         finally:


### PR DESCRIPTION
Perform a periodic update of the tools in [`pre-commit`](https://pre-commit.com).

% `pre-commit install`
```
pre-commit installed at .git/hooks/pre-commit
```
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v4.5.0 -> v4.6.0
[https://github.com/astral-sh/ruff-pre-commit] updating v0.1.5 -> v0.5.5
[https://github.com/fsfe/reuse-tool] updating v2.1.0 -> v4.0.3
```
% `pre-commit run --all-files`
```
[ ... ]
ruff.....................................................................Failed
- hook id: ruff
- files were modified by this hook

warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'extend-ignore' -> 'lint.extend-ignore'
  - 'select' -> 'lint.select'

Fixed 1 error:
- tests/test_editable.py:
    1 × RUF100 (unused-noqa)

Found 1 error (1 fixed, 0 remaining).
```
* Manually edited `pyproject.toml` to add `lint.` in two places to match `ruff`'s new syntax.