### PR TITLE
DOC: make the documentation reproducible when rebuilt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,15 +16,21 @@
 
 import datetime
 import os
+import time
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 import mesonpy
+
+build_date = datetime.datetime.fromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+    tz=datetime.timezone.utc,
+)
 
 
 # -- Project information -----------------------------------------------------
 
 project = 'meson-python'
-copyright = f'2021\N{EN DASH}{datetime.date.today().year} The meson-python developers'
+copyright = f'2021\N{EN DASH}{build_date.year} The meson-python developers'
 
 # The short X.Y version
 version = mesonpy.__version__


### PR DESCRIPTION
* From: @lamby

    Make the documentation reproducible when rebuilt
    
    The Reproducible Builds project aims to arrange for rebuilding the same
    source code in a sufficiently similar environment to produce the same
    installable packages every time, as a way to discourage supply-chain
    attacks by making it possible to verify that a particular installable
    package was built from the claimed source code.
    
    Previously, if meson-python was built twice, at least a year apart,
    then its documentation would contain different copyright dates. The
    SOURCE_DATE_EPOCH environment variable is used here to avoid that
    difference: the intention is that environments that want to produce
    reproducible packages will set SOURCE_DATE_EPOCH to some suitable fixed
    date (perhaps the date of the most recent git commit) which is held
    constant across rebuilds.
    
    See the specification for SOURCE_DATE_EPOCH for more details:
    https://reproducible-builds.org/docs/source-date-epoch/
    
    [smcv: Added commit message]
    
    Co-authored-by: @smcv

---

The actual change here is a patch originally sent to <https://bugs.debian.org/1076806>.