### PR TITLE
CI: use a token for the Codecov action to upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,6 +138,8 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@v4
         if: ${{ always() }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   msvc:
     runs-on: windows-latest


### PR DESCRIPTION
This is required now, it was a breaking change in `codecov-action@v4`. Follows up on https://github.com/mesonbuild/meson-python/pull/479#issuecomment-2265134409.

The token didn't exist yet; I just added it as a repository secret.