### PR TITLE
CI: update Cirrus CI job to use FreeBSD 14.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ opensuse-15_task:
 
 freebsd_task:
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-14-0
   install_script: pkg install -y git ninja
   << : *test
 

--- a/ci/alpine-3.docker
+++ b/ci/alpine-3.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20240305
+# 20240817
 FROM alpine:3
 RUN apk add --no-cache python3-dev py3-pip build-base ninja-is-really-ninja git patchelf

--- a/ci/opensuse-15.docker
+++ b/ci/opensuse-15.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20230816
+# 20240817
 FROM opensuse/leap:latest
 RUN zypper --non-interactive install python311 python311-pip python311-devel gcc ninja git patchelf && zypper clean --all && ln -s python3.11 /usr/bin/python3


### PR DESCRIPTION
The Free BSD 13.2 VM image used so far has been retired.