### PR TITLE
Sync tags change from packaging to support GraalPy

### DIFF
--- a/mesonpy/_tags.py
+++ b/mesonpy/_tags.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 import platform
+import struct
 import sys
 import sysconfig
 import typing
@@ -25,7 +26,7 @@ INTERPRETERS = {
 }
 
 
-_32_BIT_INTERPRETER = sys.maxsize <= 2**32
+_32_BIT_INTERPRETER = struct.calcsize('P') == 4
 
 
 def get_interpreter_tag() -> str:


### PR DESCRIPTION
Add change of `tags.py` from https://github.com/pypa/packaging/pull/711. It is necessary to get correct tags on GraalPy, because GraalPy has lower `sys.maxsize` on 64-bit due to JVM limitations.