### PR TITLE
Better error message for install_subdir with inexisting directory

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -119,7 +119,7 @@ def _map_to_wheel(sources: Dict[str, Dict[str, Any]]) -> DefaultDict[str, List[T
                         f'It is recommended to set it in "import(\'python\').find_installation()"')
 
             if key == 'install_subdirs' or key == 'targets' and os.path.isdir(src):
-                assert os.path.isdir(src)
+                assert os.path.isdir(src), f'Directory {src} does not exist'
                 exclude_files = {os.path.normpath(x) for x in target.get('exclude_files', [])}
                 exclude_dirs = {os.path.normpath(x) for x in target.get('exclude_dirs', [])}
                 for root, dirnames, filenames in os.walk(src):


### PR DESCRIPTION
Currently just `AssertionError` is shown. This will display `AssertionError: Directory /wrong/dir does not exist`.