### PR TITLE
BUG: allow install_subdir() of missing directories

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -119,7 +119,6 @@ def _map_to_wheel(sources: Dict[str, Dict[str, Any]]) -> DefaultDict[str, List[T
                         f'It is recommended to set it in "import(\'python\').find_installation()"')
 
             if key == 'install_subdirs' or key == 'targets' and os.path.isdir(src):
-                assert os.path.isdir(src)
                 exclude_files = {os.path.normpath(x) for x in target.get('exclude_files', [])}
                 exclude_dirs = {os.path.normpath(x) for x in target.get('exclude_dirs', [])}
                 for root, dirnames, filenames in os.walk(src):


### PR DESCRIPTION
Remove the assert that made sure the source path for install_subdir() is an existing directory. Meson warns in this case but allows it. Empty directories for missing source directories are not created in the Python wheel as these are hardly meaningful.