### PR TITLE
ci: Update Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           - windows-latest
         python:
           - '3.7'
-          - '3.12'
+          - '3.13'
         meson:
           -
         pyproject_metadata:
@@ -291,8 +291,8 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '3.8'
-          - '3.11'
+          - '3.9'
+          - '3.12'
         meson:
           -
 


### PR DESCRIPTION
Homebrew discontinued CPython 3.8. Switch testing Python 3.9 and 3.13 on this platform. Add CPython 3.13 to the regular test matrix.