### PR TITLE
MAINT: set version to 0.18.0.dev0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-project('meson-python', version: '0.17.0')
+project('meson-python', version: '0.18.0.dev0')
 
 py = import('python').find_installation()
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -65,7 +65,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     MesonArgs = Mapping[MesonArgsKeys, List[str]]
 
 
-__version__ = '0.17.0.dev0'
+__version__ = '0.18.0.dev0'
 
 
 _NINJA_REQUIRED_VERSION = '1.8.2'


### PR DESCRIPTION
The 0.17.0 release is up.

In the `0.17.0` tag we did unfortunately forget to bump the version string in the docs, so the deployed docs say `0.17.0.dev0`. Not a major issue, but a slight annoyance - needs a manual docs deployment to fix.