### PR TITLE
MAINT: bump minimum required Meson version to 0.64.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,9 +72,6 @@ jobs:
           # from the stdlib in Python 3.12, thus test with Pythn 3.11.
           - os: ubuntu-latest
             python: '3.11'
-            meson: '~=0.63.3'
-          - os: ubuntu-latest
-            python: '3.11'
             meson: '~=0.64.0'
           - os: ubuntu-latest
             python: '3.11'

--- a/docs/reference/meson-compatibility.rst
+++ b/docs/reference/meson-compatibility.rst
@@ -26,6 +26,12 @@ versions.
    and similar installation functions. On older Meson versions, these
    arguments have no effect.
 
+.. option:: 1.2.0
+
+   Meson 1.2.0 or later is required to support the ``--skip-subprojects``
+   option that can be passed to ``meson install`` to not include files
+   installed by some or all subprojects in the Python wheel.
+
 .. option:: 1.2.3
 
    Meson 1.2.3 or later is required to support Python 3.12 or later.

--- a/docs/reference/meson-compatibility.rst
+++ b/docs/reference/meson-compatibility.rst
@@ -15,9 +15,9 @@ maintain compatibility with as old as possible Meson releases.
 However, some functionality is available only with more recent Meson
 versions.
 
-.. option:: 0.63.3
+.. option:: 0.64.0
 
-   Meson is 0.63.3 is the minimum required version.
+   Meson is 0.64.0 is the minimum required version.
 
 .. option:: 1.1.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 build-backend = 'mesonpy'
 backend-path = ['.']
 requires = [
-  'meson >= 0.63.3; python_version < "3.12"',
+  'meson >= 0.64.0; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
   'packaging >= 19.0',
   'pyproject-metadata >= 0.8.0',
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-  'meson >= 0.63.3; python_version < "3.12"',
+  'meson >= 0.64.0; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
   'packaging >= 19.0',
   'pyproject-metadata >= 0.8.0',

--- a/tests/packages/subdirs/meson.build
+++ b/tests/packages/subdirs/meson.build
@@ -6,24 +6,7 @@ project('subdirs', version: '1.0.0')
 
 py = import('python').find_installation()
 
-# in Meson >= 0.64 this could be replace with a single
-# py.install_sources() with the 'preserve_path: true' argument.
 py.install_sources(
     'subdirs/__init__.py',
-    subdir: 'subdirs',
-)
-
-py.install_sources(
-    'subdirs/a/__init__.py',
-    subdir: 'subdirs/a',
-)
-
-py.install_sources(
-    'subdirs/a/b/c.py',
-    subdir: 'subdirs/a/b',
-)
-
-py.install_sources(
-    'subdirs/b/c.py',
-    subdir: 'subdirs/b',
+    preserve_path: true,
 )


### PR DESCRIPTION
Depending on 0.64.0 or later allows to use the pure argument when invoking the import('python').find_installation() Meson function, which makes for some nicer test and example code. Meson 0.64.0 was released on November 6th, 2022, just over a month after the current minimum supported version.