### PR TITLE
DOC: minor tweak to docs on invoking pypa/build

### DIFF
--- a/docs/how-to-guides/config-settings.rst
+++ b/docs/how-to-guides/config-settings.rst
@@ -24,7 +24,7 @@ the ``-C`` short command line option:
 
       .. code-block:: console
 
-         $ python -m build \
+         $ python -m build --wheel \
                -Csetup-args="-Doption=true" \
                -Csetup-args="-Dvalue=1" \
                -Ccompile-args="-j6"
@@ -34,11 +34,10 @@ the ``-C`` short command line option:
 
       .. code-block:: console
 
-	 $ python -m pip wheel . \
+         $ python -m pip wheel . \
                -Csetup-args="-Doption=true" \
                -Csetup-args="-Dvalue=1" \
                -Ccompile-args="-j6"
-
 
 Refer to the `build`_ and `pip`_ documentation for details.  This
 example uses the ``python -m pip wheel`` command to build a Python wheel
@@ -76,18 +75,18 @@ For example:
 .. tab-set::
 
     .. tab-item:: pypa/build
-        :sync: key_pypa_build
+       :sync: key_pypa_build
 
-	.. code-block:: console
+       .. code-block:: console
 
-	   $ python -m build -Cbuild-dir=build
+          $ python -m build --wheel -Cbuild-dir=build
 
     .. tab-item:: pip
-        :sync: key_pip
+       :sync: key_pip
 
-	.. code-block:: console
+       .. code-block:: console
 
-	   $ python -m pip install . -Cbuild-dir=build
+          $ python -m pip install . -Cbuild-dir=build
 
 After running this command, the ``build`` directory will contain all
 the build artifacts and support files created by ``meson``, ``ninja``

--- a/docs/how-to-guides/meson-args.rst
+++ b/docs/how-to-guides/meson-args.rst
@@ -83,7 +83,7 @@ To set this option temporarily at build-time:
 
       .. code-block:: console
 
-         $ python -m build -Csetup-args="--default-library=static" .
+         $ python -m build --wheel -Csetup-args="--default-library=static" .
 
    .. tab-item:: pip
       :sync: key_pip
@@ -125,7 +125,7 @@ To set this option temporarily at build-time:
 
       .. code-block:: console
 
-         $ python -m build -Cinstall-args="--tags=runtime,python-runtime" .
+         $ python -m build --wheel -Cinstall-args="--tags=runtime,python-runtime" .
 
    .. tab-item:: pip
       :sync: key_pip
@@ -158,7 +158,7 @@ To set this option temporarily at build-time:
 
       .. code-block:: console
 
-         $ python -m build -Csetup-args="-Doptimization=3" .
+         $ python -m build --wheel -Csetup-args="-Doptimization=3" .
 
    .. tab-item:: pip
       :sync: key_pip
@@ -207,11 +207,11 @@ To set this option temporarily at build-time:
 
       .. code-block:: console
 
-	 $ python -m build -Csetup-args="--vsenv" .
+         $ python -m build --wheel -Csetup-args="--vsenv" .
 
    .. tab-item:: pip
       :sync: key_pip
 
       .. code-block:: console
 
-	 $ python -m pip wheel -Csetup-args="--vsenv" .
+         $ python -m pip wheel -Csetup-args="--vsenv" .

--- a/docs/tutorials/introduction.rst
+++ b/docs/tutorials/introduction.rst
@@ -228,7 +228,8 @@ Building the project
 
 Before continuing, ensure you have committed the three files we created so far
 to your Git repository - ``meson-python`` will only take into account the files
-that Git knows about.
+that Git knows about, and an sdist is created from the most recent commit -
+uncommitted changes are ignored.
 
 To generate the distribution artifacts we will use the `pypa/build`_ tool. It
 will create a temporary virtual environment, install all the required build
@@ -240,6 +241,9 @@ dependencies, and ask ``meson-python`` to build the artifacts.
    $ python -m build
 
 If the build succeeded, you'll have the binary artifacts in the ``dist`` folder.
+Note that by default, ``python -m build`` builds an sdist first, and then a
+wheel from the sdist. If you only want one artifact, add ``--sdist`` or
+``--wheel`` to the invocation.
 
 .. admonition:: Building wheels for multiple platforms
    :class: tip


### PR DESCRIPTION
Addresses [a comment on gh-704](https://github.com/mesonbuild/meson-python/issues/704#issuecomment-2466694466), where a user got tripped up by `python -m build` building an sdist first (and that's typically not what you want).