### PR TITLE
MAINT: put back mesonpy.__version__

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,9 +41,9 @@ debian-unstable_task:
     cpu: 1
   << : *test
 
-fedora-37_task:
+fedora-41_task:
   container:
-    dockerfile: ci/fedora-37.docker
+    dockerfile: ci/fedora-41.docker
     cpu: 1
   << : *test
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -19,7 +19,7 @@ After that is done, you may release the project by following these steps:
 
    #. Create the release commit
 
-      #. Bump the versions in ``pyproject.toml``.
+      #. Bump the versions in ``pyproject.toml`` and in ``mesonpy/__init__.py``.
       #. Create ``CHANGELOG.rst`` section for the new release and fill it.
       #. The commit message should read: ``REL: set version to X.Y.Z``
 

--- a/ci/archlinux.docker
+++ b/ci/archlinux.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20221203
+# 20250127
 FROM archlinux:latest
 RUN pacman -Syu --noconfirm && pacman -S --noconfirm python python-pip gcc ninja git patchelf

--- a/ci/debian-12.docker
+++ b/ci/debian-12.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20240204
+# 20250127
 FROM debian:bookworm
 RUN apt-get update && apt-get install -y git ninja-build patchelf python3-pip python3-venv && rm -rf /var/lib/apt/lists/*

--- a/ci/fedora-41.docker
+++ b/ci/fedora-41.docker
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# 20240204
-FROM fedora:37
+# 20250127
+FROM fedora:41
 RUN dnf -y update && dnf -y install python3-devel python3-pip gcc ninja-build git patchelf && dnf clean all

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -79,6 +79,9 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     MesonArgs = Mapping[MesonArgsKeys, List[str]]
 
 
+__version__ = '0.18.0.dev0'
+
+
 _PYPROJECT_METADATA_VERSION = tuple(map(int, pyproject_metadata.__version__.split('.')[:2]))
 _SUPPORTED_DYNAMIC_FIELDS = {'version', } if _PYPROJECT_METADATA_VERSION < (0, 9) else {'version', 'license', 'license-files'}
 

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -11,6 +11,15 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+import mesonpy
+
+
+def test_version():
+    pyproject = pathlib.Path(__file__).parent.parent.joinpath('pyproject.toml')
+    with open(pyproject, 'rb') as f:
+        project_version = tomllib.load(f)['project']['version']
+    assert mesonpy.__version__ == project_version
+
 
 def test_pyproject_dependencies():
     pyproject = pathlib.Path(__file__).parent.parent.joinpath('pyproject.toml')


### PR DESCRIPTION
The module constant has been used to check meson-python version in other projects, see discussion on #691.  Add a test to ensure that the version recorded in `pyproject.toml` and `mesonpy/__init__.py` are kept in sync.