### PR TITLE
Add support for targeting iOS.

### DIFF
--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -61,6 +61,22 @@ Environment variables used by meson-python
 .. _cross build definition file: https://mesonbuild.com/Cross-compilation.html
 .. _cibuildwheel: https://cibuildwheel.readthedocs.io/en/stable/
 
+.. envvar:: IPHONEOS_DEPLOYMENT_TARGET
+
+   This environment variable is used to specify the target iOS platform version
+   to the Xcode development tools.  If this environment variable is set,
+   ``meson-python`` will use the specified iOS version for the Python wheel
+   platform tag, instead than the iOS platform default of 13.0.
+
+   This variable must be set to a major/minor version, for example ``13.0`` or
+   ``15.4``.
+
+   Note that ``IPHONEOS_DEPLOYMENT_TARGET`` is the only supported mechanism
+   for specifying the target iOS version. Although the iOS toolchain supports
+   the use of ``-mios-version-min`` compile and link flags to set the target iOS
+   version, ``meson-python`` will not set the Python wheel platform tag
+   correctly unless ``IPHONEOS_DEPLOYMENT_TARGET`` is set.
+
 .. envvar:: FORCE_COLOR
 
    Setting this environment variable to any value forces the use of ANSI
@@ -69,11 +85,10 @@ Environment variables used by meson-python
 
 .. envvar:: MACOSX_DEPLOYMENT_TARGET
 
-   This environment variables is used of specifying the target macOS platform
-   major version to the Xcode development tools.  If this environment variable
-   is set, ``meson-python`` will use the specified macOS version for the
-   Python wheel platform tag instead than the macOS version of the build
-   machine.
+   This environment variable is used to specify the target macOS platform major
+   version to the Xcode development tools.  If this environment variable is set,
+   ``meson-python`` will use the specified macOS version for the Python wheel
+   platform tag instead than the macOS version of the build machine.
 
    This variable must be set to macOS major versions only: ``10.9`` to
    ``10.15``, ``11``, ``12``, ``13``, ...
@@ -84,10 +99,11 @@ Environment variables used by meson-python
    are currently designed to specify compatibility only with major version
    number granularity.
 
-   Another way of specifying the target macOS platform is to use the
-   ``-mmacosx-version-min`` compile and link flags.  However, it is not
-   possible for ``meson-python`` to detect this, and it will not set the
-   Python wheel platform tag accordingly.
+   Note that ``MACOSX_DEPLOYMENT_TARGET`` is the only supported mechanism for
+   specifying the target macOS version. Although the macOS toolchain supports
+   the use of ``-mmacosx-version-min`` compile and link flags to set the target
+   macOS version, ``meson-python`` will not set the Python wheel platform tag
+   correctly unless ``MACOSX_DEPLOYMENT_TARGET`` is set.
 
 .. envvar:: MESON
 

--- a/docs/reference/meson-compatibility.rst
+++ b/docs/reference/meson-compatibility.rst
@@ -52,6 +52,10 @@ versions.
    populate the package license and license files from the ones
    declared via the ``project()`` call in ``meson.build``.
 
+.. option:: 1.9.0
+
+   Meson 1.9.0 or later is required to support building for iOS.
+
 Build front-ends by default build packages in an isolated Python
 environment where build dependencies are installed. Most often, unless
 a package or its build dependencies declare explicitly a version

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -719,6 +719,30 @@ class Project():
                     ''')
                     self._meson_cross_file.write_text(cross_file_data, encoding='utf-8')
                     self._meson_args['setup'].extend(('--cross-file', os.fspath(self._meson_cross_file)))
+        elif sysconfig.get_platform().startswith('ios-'):
+            ios_ver = platform.ios_ver()  # type: ignore[attr-defined]
+
+            arch = platform.machine()
+            family = 'aarch64' if arch == 'arm64' else arch
+            subsystem = 'ios-simulator' if ios_ver.is_simulator else 'ios'
+
+            cross_file_data = textwrap.dedent(f'''
+                [binaries]
+                c = '{arch}-apple-{subsystem}-clang'
+                cpp = '{arch}-apple-{subsystem}-clang++'
+                objc = '{arch}-apple-{subsystem}-clang'
+                objcpp = '{arch}-apple-{subsystem}-clang++'
+                ar = '{arch}-apple-{subsystem}-ar'
+
+                [host_machine]
+                system = 'ios'
+                subsystem = {subsystem!r}
+                cpu = {arch!r}
+                cpu_family = {family!r}
+                endian = 'little'
+            ''')
+            self._meson_cross_file.write_text(cross_file_data, encoding='utf-8')
+            self._meson_args['setup'].extend(('--cross-file', os.fspath(self._meson_cross_file)))
 
         # write the native file
         native_file_data = textwrap.dedent(f'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ backend-path = ['.']
 requires = [
   'meson >= 0.64.0; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
-  'packaging >= 23.2',
+  'packaging >= 23.2; sys_platform != "ios"',
+  'packaging >= 24.2; sys_platform == "ios"',
   'pyproject-metadata >= 0.9.0',
   'tomli >= 1.0.0; python_version < "3.11"',
 ]
@@ -37,7 +38,8 @@ classifiers = [
 dependencies = [
   'meson >= 0.64.0; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
-  'packaging >= 23.2',
+  'packaging >= 23.2; sys_platform != "ios"',
+  'packaging >= 24.2; sys_platform == "ios"',
   'pyproject-metadata >= 0.9.0',
   'tomli >= 1.0.0; python_version < "3.11"',
 ]


### PR DESCRIPTION
Adds the modifications required to support targeting iOS.

Assumes meson is running in a cross-platform virtual environment, where `sys.platform == "ios"`, and other platform identification tags are "mocked" versions of an iOS environment (matching what cibuildwheel's iOS support does).

Functionally, it's very similar to macOS build support - it writes a cross-build configuration file, based on the contents of sysconfigdata.

The bump in the version of Packaging is required so that iOS platform tag handling is available.