### PR TITLE
Add libdir static

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -106,6 +106,7 @@ _INSTALLATION_PATH_MAP = {
     # custom location
     '{libdir}': 'mesonpy-libs',
     '{libdir_shared}': 'mesonpy-libs',
+    '{libdir_static}': 'mesonpy-libs',
 }
 
 


### PR DESCRIPTION
Some packages with static libraries report an error.

meson-python: error: Could not map installation path to an equivalent
wheel directory: '{libdir_static}/libjson-c.a'

Possibly related to https://github.com/mesonbuild/meson/issues/12846

Example of this error occurring is here:
https://github.com/edtanous/libcper/tree/pypi

