### PR TITLE
MAINT: bump minimum packaging version to 23.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ backend-path = ['.']
 requires = [
   'meson >= 0.64.0; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
-  'packaging >= 19.0',
+  'packaging >= 23.2',
   'pyproject-metadata >= 0.9.0',
   'tomli >= 1.0.0; python_version < "3.11"',
 ]
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
   'meson >= 0.64.0; python_version < "3.12"',
   'meson >= 1.2.3; python_version >= "3.12"',
-  'packaging >= 19.0',
+  'packaging >= 23.2',
   'pyproject-metadata >= 0.9.0',
   'tomli >= 1.0.0; python_version < "3.11"',
 ]
@@ -44,7 +44,6 @@ dependencies = [
 [project.optional-dependencies]
 test = [
   'build',
-  'packaging >= 23.1',
   'pytest >= 6.0',
   'pytest-cov[toml]',
   'pytest-mock',


### PR DESCRIPTION
pyproject-metadata 0.9.1 requires packaging 23.2 or later, but does not record this dependency, see https://github.com/pypa/pyproject-metadata/pull/239

This becomes a problem when meson-python is installed on a platform where packaging 19.0 (the current minimum required version) is installed. This does not trigger an update of packaging to the latest available version and results in run time errors, see https://github.com/scipy/scipy/pull/22840#issuecomment-2817494211

This could be fixed by a new release of pyproject-metadata, but we do not want meson-python to depend on very recent releases. meson-python supports pyproject-metadata 0.9.0 or later and still carries some work-arounds for issues in that release.

The least invasive and most effective solution is to bump the packaging requirement for meson-python to 23.2. This also fixes the (intentional) use of API available only with packaging 23.2 or later in the meson-python tests.

Fixes #733.