### PR TITLE
MAINT: switch to PEP639 license declaration for meson-python itself

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ version = '0.18.0.dev0'
 description = 'Meson Python build backend (PEP 517)'
 readme = 'README.rst'
 requires-python = '>= 3.8'
-license = { file = 'LICENSES/MIT.txt' }
+license = 'MIT'
+license-files = ['LICENSES/MIT.txt']
 keywords = ['meson', 'build', 'backend', 'pep517', 'package']
 maintainers = [
   { name = 'Ralf Gommers', email = 'ralf.gommers@gmail.com' },


### PR DESCRIPTION
meson-python uses itself as a build backend, thus we can switch to PEP639 license declaration now that meson-python supports it.