### PR TITLE
BUG: fix a problem with symlink support

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -966,6 +966,9 @@ class Project():
                         warnings.warn(
                             f'symbolic link pointing to a directory ignored: {name}', stacklevel=1)
 
+                # Copy `member` before starting to modify it
+                member = copy.copy(member)
+
                 if member.isfile():
                     file = meson_dist.extractfile(member.name)
 

--- a/tests/packages/symlinks/meson.build
+++ b/tests/packages/symlinks/meson.build
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-project('symlinks', version: '1.0.0')
+project('symlinks')
 
 py = import('python').find_installation()
 

--- a/tests/packages/symlinks/pyproject.toml
+++ b/tests/packages/symlinks/pyproject.toml
@@ -5,3 +5,7 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = ['meson-python']
+
+[project]
+name = 'symlinks'
+version = '1.0.0'


### PR DESCRIPTION
Modifies the existing `symlinks` test package so it exercises the bug. The situation without a `version` keyword in `meson.build` is more difficult because the dist tarball generated by Meson will be named `<project-name>-undefined.tar.gz`, which meson-python then changes to `<project-name-version.tar.gz`.

_Note: I didn't include the dist script part discussed in https://github.com/mesonbuild/meson-python/pull/728#issuecomment-2848691677, because I'm out of time right now. I think it should be done, but it's not blocking for 0.18.0 I think._