### PR TITLE
MAINT: avoid warnings because of symlinks pointing outside repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+# These test files contain symlinks to outside the repo (hence invalid - on
+# purpose) so exclude them to prevent warnings. See gh-728 for context.
+tests/packages/symlinks/baz.py export-ignore
+tests/packages/symlinks/qux.py export-ignore

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -223,6 +223,10 @@ def test_symlinks(tmp_path, sdist_symlinks):
         names = {member.name for member in sdist.getmembers()}
         mtimes = {member.mtime for member in sdist.getmembers()}
 
+    # Check that the symlinks `baz.py` and `qux.py` pointing outside the
+    # source tree are not included. These files are present in the
+    # meson-python git repository but cannot be included in the meson-python
+    # sdist. Thus this test is effective only when run from a git checkout.
     assert names == {
         'symlinks-1.0.0/PKG-INFO',
         'symlinks-1.0.0/meson.build',


### PR DESCRIPTION
Follows up on https://github.com/mesonbuild/meson-python/pull/728#issuecomment-2848691677 and gh-745.