### PR TITLE
Correct typo in docstring.

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -760,7 +760,7 @@ class Project():
             if 'license-files' in self._metadata.dynamic:
                 self._metadata.license_files = self._meson_license_files
         else:
-            # if project section is missing, use minimal metdata from meson.build
+            # if project section is missing, use minimal metadata from meson.build
             name, version = self._meson_name, self._meson_version
             if not version:
                 raise pyproject_metadata.ConfigurationError(


### PR DESCRIPTION
Corrects metdata->metadata at suggestion of @rgommers (mostly so I can no longer be a first-time contributor requiring manual CI approval)