### PR TITLE
Print meson output in case of error during editable rebuild

### DIFF
--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -344,9 +344,10 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             else:
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env, stdout=subprocess.DEVNULL, check=True)
         except subprocess.CalledProcessError as exc:
-            output = exc.output.decode(errors="replace") if exc.output is not None else "No error details available"
-            raise ImportError(f're-building the {self._name} meson-python editable wheel package failed with: \n{output}') from exc
-
+            output = exc.output.decode(errors='replace') if exc.output is not None else "No error details available"
+            raise ImportError(
+                f're-building the {self._name} meson-python editable wheel package failed with: \n{output}'
+            ) from exc
 
         install_plan_path = os.path.join(self._build_path, 'meson-info', 'intro-install_plan.json')
         with open(install_plan_path, 'r', encoding='utf8') as f:

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -344,7 +344,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             else:
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env, stdout=subprocess.DEVNULL, check=True)
         except subprocess.CalledProcessError as exc:
-            output = exc.output.decode(errors='replace') if exc.output is not None else "No error details available"
+            output = exc.output.decode(errors='replace') if exc.output is not None else 'No error details available'
             raise ImportError(
                 f're-building the {self._name} meson-python editable wheel package failed with: \n{output}'
             ) from exc

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -340,9 +340,23 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
                 if self._work_to_do(env):
                     build_command = ' '.join(self._build_cmd)
                     print(f'meson-python: building {self._name}: {build_command}', flush=True)
-                    subprocess.run(self._build_cmd, cwd=self._build_path, env=env, check=True)
+                    subprocess.run(
+                        self._build_cmd,
+                        cwd=self._build_path,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        env=env,
+                        check=True,
+                    )
             else:
-                subprocess.run(self._build_cmd, cwd=self._build_path, env=env, stdout=subprocess.DEVNULL, check=True)
+                subprocess.run(
+                    self._build_cmd,
+                    cwd=self._build_path,
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    check=True,
+                )
         except subprocess.CalledProcessError as exc:
             output = exc.output.decode(errors='replace') if exc.output is not None else 'No error details available'
             raise ImportError(

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -344,8 +344,8 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             else:
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env, stdout=subprocess.DEVNULL, check=True)
         except subprocess.CalledProcessError as exc:
-            output = exc.output if exc.output is not None else exc.stdout
-            raise ImportError(f're-building the {self._name} meson-python editable wheel package failed with: \n{output.decode(errors="replace")}') from exc
+            output = exc.output.decode(errors="replace") if exc.output is not None else "No error details available"
+            raise ImportError(f're-building the {self._name} meson-python editable wheel package failed with: \n{output}') from exc
 
 
         install_plan_path = os.path.join(self._build_path, 'meson-info', 'intro-install_plan.json')

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -344,7 +344,9 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
             else:
                 subprocess.run(self._build_cmd, cwd=self._build_path, env=env, stdout=subprocess.DEVNULL, check=True)
         except subprocess.CalledProcessError as exc:
-            raise ImportError(f're-building the {self._name} meson-python editable wheel package failed') from exc
+            output = exc.output if exc.output is not None else exc.stdout
+            raise ImportError(f're-building the {self._name} meson-python editable wheel package failed with: \n{output.decode(errors="replace")}') from exc
+
 
         install_plan_path = os.path.join(self._build_path, 'meson-info', 'intro-install_plan.json')
         with open(install_plan_path, 'r', encoding='utf8') as f:

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -336,7 +336,9 @@ def test_editable_rebuild_error(package_purelib_and_platlib, tmp_path, verbose):
             # Import module and trigger rebuild: the build fails and ImportErrror is raised
             stdout = io.StringIO()
             with redirect_stdout(stdout):
-                with pytest.raises(ImportError, match=r're-building the purelib-and-platlib (?s:.)*error: expected identifier'):
+                with pytest.raises(
+                    ImportError, match=r're-building the purelib-and-platlib (?s:.)*error: expected identifier'
+                ):
                     import plat  # noqa: F401
             if verbose:
                 assert stdout.getvalue().startswith('meson-python: building ')
@@ -348,13 +350,15 @@ def test_editable_rebuild_error(package_purelib_and_platlib, tmp_path, verbose):
             sys.modules.pop('pure', None)
             path.write_text(code)
 
+
 @pytest.mark.parametrize('verbose', [False, True], ids=('', 'verbose'))
 def test_editable_meson_file_rebuild_error(package_purelib_and_platlib, tmp_path, verbose):
     with mesonpy._project({'builddir': os.fspath(tmp_path)}) as project:
-
         finder = _editable.MesonpyMetaFinder(
-            project._metadata.name, {'plat', 'pure'},
-            os.fspath(tmp_path), project._build_command,
+            project._metadata.name,
+            {'plat', 'pure'},
+            os.fspath(tmp_path),
+            project._build_command,
             verbose=verbose,
         )
         path = package_purelib_and_platlib / 'meson.build'
@@ -370,7 +374,9 @@ def test_editable_meson_file_rebuild_error(package_purelib_and_platlib, tmp_path
             # Import module and trigger rebuild: the build fails and ImportErrror is raised
             stdout = io.StringIO()
             with redirect_stdout(stdout):
-                with pytest.raises(ImportError, match=r're-building the purelib-and-platlib (?s:.)*ERROR: Invalid source tree:'):
+                with pytest.raises(
+                    ImportError, match=r're-building the purelib-and-platlib (?s:.)*ERROR: Invalid source tree:'
+                ):
                     import plat  # noqa: F401
             if verbose:
                 assert stdout.getvalue().startswith('meson-python: building ')

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -369,7 +369,7 @@ def test_editable_meson_file_rebuild_error(package_purelib_and_platlib, tmp_path
             sys.meta_path.insert(0, finder)
 
             # Insert invalid code in the meson build file
-            path.write_text('return')
+            path.write_text('<not valid')
 
             # Import module and trigger rebuild: the build fails and ImportErrror is raised
             stdout = io.StringIO()


### PR DESCRIPTION
In case there is an error during the call of meson build, it currently only prints
```
Traceback (most recent call last):
  File "/opt/conda/envs/sage-dev/lib/python3.11/site-packages/_sagemath_editable_loader.py", line 345, in _rebuild
    result = subprocess.run(
             ^^^^^^^^^^^^^^^
  File "/opt/conda/envs/sage-dev/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/opt/conda/envs/sage-dev/bin/ninja']' returned non-zero exit status 1.
```
in the console. This is not very helpful to diagonize the problem. With this PR, the full output of meson is printed.

EDIT: addresses a part of gh-820