### PR TITLE
MAINT: add config for ruff formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ known-first-party = [
   'mesonpy',
 ]
 
+[tool.ruff.format]
+quote-style = 'single'
+
 
 [tool.coverage.run]
 disable_warnings = [


### PR DESCRIPTION
Add configuration for the ruff formatter to enforce single quotes for strings, otherwise it constantly reformats the strings to double-quotes.