### PR TITLE
MAINT: add `ninja` to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
   'pytest-cov[toml]',
   'pytest-mock',
   'cython >= 3.0.3', # required for Python 3.12 support
+  'ninja',
   'wheel',
   'typing-extensions >= 3.7.4; python_version < "3.11"',
 ]


### PR DESCRIPTION
It's needed to run the tests.

But the CI spends some time to install ninja from the system; so I'm not sure what's the best approach here. Maybe add a dev group?