### PR TITLE
MAINT: move Thomas Li to emeritus maintainer

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -23,11 +23,11 @@ The current maintainers of ``meson-python`` are:
 - `Ralf Gommers <https://github.com/rgommers>`_
 - `Daniele Nicolodi <https://github.com/dnicolodi>`_
 - `Henry Schreiner <https://github.com/henryiii>`_
-- `Thomas Li <https://github.com/lithomas1>`_
 
 Emeritus maintainers:
 
 - `Filipe Laíns <https://github.com/FFY00>`_
+- `Thomas Li <https://github.com/lithomas1>`_
 
 
 Funding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ maintainers = [
   { name = 'Ralf Gommers', email = 'ralf.gommers@gmail.com' },
   { name = 'Daniele Nicolodi', email = 'daniele@grinta.net' },
   { name = 'Henry Schreiner', email = 'HenrySchreinerIII@gmail.com' },
-  { name = 'Thomas Li', email = '47963215+lithomas1@users.noreply.github.com' },
 ]
 classifiers = [
   'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
@lithomas1 indicated to me that he doesn't plan on exercising his commit rights anymore and is happy to be moved to emeritus status.