### PR TITLE
MAINT: fix ruff configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,10 +76,15 @@ strict = true
 
 [tool.ruff]
 line-length = 127
-lint.extend-ignore = [
+
+[tool.ruff.format]
+quote-style = 'single'
+
+[tool.ruff.lint]
+extend-ignore = [
   'B019',
 ]
-lint.select = [
+select = [
   'B',       # flake8-bugbear
   'C4',      # flake8-comprehensions
   'E',       # pycodestyle
@@ -92,9 +97,6 @@ lint.select = [
 exclude = [
   'docs/conf.py',
 ]
-
-[tool.ruff.format]
-quote-style = 'single'
 
 [tool.ruff.lint.flake8-quotes]
 avoid-escape = false


### PR DESCRIPTION
This change fixes something that may be invalid TOML, aligns better with the docs at https://docs.astral.sh/ruff/configuration, and avoids Pixi choking on parsing `pyproject.toml` with:

```
  79 │ lint.extend-ignore = [
     · ──┬─
     ·   ╰── first defined here
  80 │   'B019',
  81 │ ]
...
  98 │
  99 │ [tool.ruff.lint.flake8-quotes]
     ·            ──┬─
     ·              ╰── duplicate defined here
```