### PR TITLE
ENH: define strip binary in synthesized cross files

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -711,6 +711,8 @@ class Project():
                         cpp = ['c++', '-arch', {arch!r}]
                         objc = ['cc', '-arch', {arch!r}]
                         objcpp = ['c++', '-arch', {arch!r}]
+                        strip = ['strip', '-arch', {arch!r}]
+
                         [host_machine]
                         system = 'darwin'
                         cpu = {arch!r}
@@ -731,11 +733,12 @@ class Project():
 
             cross_file_data = textwrap.dedent(f'''
                 [binaries]
+                ar = '{arch}-apple-{subsystem}-ar'
                 c = '{arch}-apple-{subsystem}-clang'
                 cpp = '{arch}-apple-{subsystem}-clang++'
                 objc = '{arch}-apple-{subsystem}-clang'
                 objcpp = '{arch}-apple-{subsystem}-clang++'
-                ar = '{arch}-apple-{subsystem}-ar'
+                strip = '{arch}-apple-{subsystem}-strip'
 
                 [host_machine]
                 system = 'ios'


### PR DESCRIPTION
Extracted from #768. `strip` has been added to the CPython distributed compiler wrappers, use that.