### PR TITLE
TST: rework the sharedlib-in-package test package

### DIFF
--- a/mesonpy/_rpath.py
+++ b/mesonpy/_rpath.py
@@ -74,7 +74,7 @@ else:
 
     def _get_rpath(filepath: Path) -> List[str]:
         r = subprocess.run(['patchelf', '--print-rpath', os.fspath(filepath)], capture_output=True, text=True)
-        return r.stdout.strip().split(':')
+        return [x for x in r.stdout.strip().split(':') if x]
 
     def _set_rpath(filepath: Path, rpath: Iterable[str]) -> None:
         subprocess.run(['patchelf','--set-rpath', ':'.join(rpath), os.fspath(filepath)], check=True)

--- a/tests/packages/sharedlib-in-package/meson.build
+++ b/tests/packages/sharedlib-in-package/meson.build
@@ -6,4 +6,5 @@ project('sharedlib-in-package', 'c', version: '1.0.0')
 
 py = import('python').find_installation(pure: false)
 
+subdir('src')
 subdir('mypkg')

--- a/tests/packages/sharedlib-in-package/meson.build
+++ b/tests/packages/sharedlib-in-package/meson.build
@@ -6,5 +6,7 @@ project('sharedlib-in-package', 'c', version: '1.0.0')
 
 py = import('python').find_installation(pure: false)
 
+origin = build_machine.system() == 'darwin' ? '@loader_path' : '$ORIGIN'
+
 subdir('src')
 subdir('mypkg')

--- a/tests/packages/sharedlib-in-package/mypkg/__init__.py
+++ b/tests/packages/sharedlib-in-package/mypkg/__init__.py
@@ -45,7 +45,7 @@ _append_to_sharedlib_load_path()
 # end-literalinclude
 
 
-from ._example import example_prod, example_sum  #noqa: E402
+from ._example import prodsum  # noqa: E402
 
 
-__all__ = ['example_prod', 'example_sum']
+__all__ = ['prodsum']

--- a/tests/packages/sharedlib-in-package/mypkg/_examplemod.c
+++ b/tests/packages/sharedlib-in-package/mypkg/_examplemod.c
@@ -4,36 +4,23 @@
 
 #include <Python.h>
 
-#include "examplelib.h"
-#include "examplelib2.h"
+#include "lib.h"
 
-static PyObject* example_sum(PyObject* self, PyObject *args)
+static PyObject* example_prodsum(PyObject* self, PyObject *args)
 {
-    int a, b;
-    if (!PyArg_ParseTuple(args, "ii", &a, &b)) {
+    int a, b, x;
+
+    if (!PyArg_ParseTuple(args, "iii", &a, &b, &x)) {
         return NULL;
     }
 
-    long result = sum(a, b);
-
-    return PyLong_FromLong(result);
-}
-
-static PyObject* example_prod(PyObject* self, PyObject *args)
-{
-    int a, b;
-    if (!PyArg_ParseTuple(args, "ii", &a, &b)) {
-        return NULL;
-    }
-
-    long result = prod(a, b);
+    long result = prodsum(a, b, x);
 
     return PyLong_FromLong(result);
 }
 
 static PyMethodDef methods[] = {
-    {"example_prod", (PyCFunction)example_prod, METH_VARARGS, NULL},
-    {"example_sum", (PyCFunction)example_sum, METH_VARARGS, NULL},
+    {"prodsum", (PyCFunction)example_prodsum, METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL},
 };
 

--- a/tests/packages/sharedlib-in-package/mypkg/examplelib.c
+++ b/tests/packages/sharedlib-in-package/mypkg/examplelib.c
@@ -1,9 +1,0 @@
-// SPDX-FileCopyrightText: 2022 The meson-python developers
-//
-// SPDX-License-Identifier: MIT
-
-#include "sub/mypkg_dll.h"
-
-MYPKG_DLL int sum(int a, int b) {
-    return a + b;
-}

--- a/tests/packages/sharedlib-in-package/mypkg/examplelib.h
+++ b/tests/packages/sharedlib-in-package/mypkg/examplelib.h
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: 2022 The meson-python developers
-//
-// SPDX-License-Identifier: MIT
-
-#include "sub/mypkg_dll.h"
-
-MYPKG_DLL int sum(int a, int b);

--- a/tests/packages/sharedlib-in-package/mypkg/meson.build
+++ b/tests/packages/sharedlib-in-package/mypkg/meson.build
@@ -11,8 +11,8 @@ py.extension_module(
     # install_rpath is not exposed in the Meson introspection data in Meson
     # versions prior to 1.6.0 and thus cannot be set by meson-python when
     # building the Python wheel. Use link_args to set the RPATH.
-    # install_rpath: '$ORIGIN',
-    link_args: '-Wl,-rpath,$ORIGIN',
+    # install_rpath: f'@origin@',
+    link_args: f'-Wl,-rpath,@origin@',
 )
 
 py.install_sources(

--- a/tests/packages/sharedlib-in-package/mypkg/meson.build
+++ b/tests/packages/sharedlib-in-package/mypkg/meson.build
@@ -2,34 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-if meson.get_compiler('c').get_id() in ['msvc', 'clang-cl', 'intel-cl']
-    export_dll_args = ['-DMYPKG_DLL_EXPORTS']
-    import_dll_args = ['-DMYPKG_DLL_IMPORTS']
-else
-    export_dll_args = []
-    import_dll_args = []
-endif
-
-example_lib = shared_library(
-    'examplelib',
-    'examplelib.c',
-    c_args: export_dll_args,
-    install: true,
-    install_dir: py.get_install_dir() / 'mypkg',
-)
-
-example_lib_dep = declare_dependency(
-    compile_args: import_dll_args,
-    link_with: example_lib,
-)
-
-subdir('sub')
-
 py.extension_module(
     '_example',
     '_examplemod.c',
-    dependencies: [example_lib_dep, example_lib2_dep],
-    include_directories: 'sub',
+    dependencies: lib_dep,
     install: true,
     subdir: 'mypkg',
     install_rpath: '$ORIGIN',

--- a/tests/packages/sharedlib-in-package/mypkg/meson.build
+++ b/tests/packages/sharedlib-in-package/mypkg/meson.build
@@ -8,7 +8,11 @@ py.extension_module(
     dependencies: lib_dep,
     install: true,
     subdir: 'mypkg',
-    install_rpath: '$ORIGIN',
+    # install_rpath is not exposed in the Meson introspection data in Meson
+    # versions prior to 1.6.0 and thus cannot be set by meson-python when
+    # building the Python wheel. Use link_args to set the RPATH.
+    # install_rpath: '$ORIGIN',
+    link_args: '-Wl,-rpath,$ORIGIN',
 )
 
 py.install_sources(

--- a/tests/packages/sharedlib-in-package/mypkg/sub/examplelib2.h
+++ b/tests/packages/sharedlib-in-package/mypkg/sub/examplelib2.h
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: 2022 The meson-python developers
-//
-// SPDX-License-Identifier: MIT
-
-#include "mypkg_dll.h"
-
-MYPKG_DLL int prod(int a, int b);

--- a/tests/packages/sharedlib-in-package/src/lib.c
+++ b/tests/packages/sharedlib-in-package/src/lib.c
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 The meson-python developers
+//
+// SPDX-License-Identifier: MIT
+
+#include "lib.h"
+#include "sublib.h"
+
+int prodsum(int a, int b, int x) {
+    return prod(a,  x) + b;
+}

--- a/tests/packages/sharedlib-in-package/src/lib.h
+++ b/tests/packages/sharedlib-in-package/src/lib.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2022 The meson-python developers
+//
+// SPDX-License-Identifier: MIT
+
+#if defined(MYPKG_DLL_EXPORTS)
+    #define EXPORT __declspec(dllexport)
+#elif defined(MYPKG_DLL_IMPORTS)
+    #define EXPORT __declspec(dllimport)
+#else
+    #define EXPORT
+#endif
+
+EXPORT int prodsum(int a, int b, int x);

--- a/tests/packages/sharedlib-in-package/src/meson.build
+++ b/tests/packages/sharedlib-in-package/src/meson.build
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2022 The meson-python developers
+#
+# SPDX-License-Identifier: MIT
+
+if meson.get_compiler('c').get_id() in ['msvc', 'clang-cl', 'intel-cl']
+    export_dll_args = ['-DMYPKG_DLL_EXPORTS']
+    import_dll_args = ['-DMYPKG_DLL_IMPORTS']
+else
+    export_dll_args = []
+    import_dll_args = []
+endif
+
+sublib = shared_library(
+    'sublib',
+    'sublib.c',
+    c_args: export_dll_args,
+    install: true,
+    install_dir: py.get_install_dir() / 'mypkg/sub',
+)
+
+sublib_dep = declare_dependency(
+    compile_args: import_dll_args,
+    link_with: sublib,
+)
+
+lib = shared_library(
+    'lib',
+    'lib.c',
+    dependencies: sublib_dep,
+    c_args: export_dll_args,
+    install: true,
+    install_dir: py.get_install_dir() / 'mypkg',
+    install_rpath: '$ORIGIN/sub',
+)
+
+lib_dep = declare_dependency(
+    compile_args: import_dll_args,
+    link_with: lib,
+    include_directories: include_directories('.'),
+)

--- a/tests/packages/sharedlib-in-package/src/meson.build
+++ b/tests/packages/sharedlib-in-package/src/meson.build
@@ -33,8 +33,8 @@ lib = shared_library(
     # install_rpath is not exposed in the Meson introspection data in Meson
     # versions prior to 1.6.0 and thus cannot be set by meson-python when
     # building the Python wheel. Use link_args to set the RPATH.
-    # install_rpath: '$ORIGIN/sub',
-    link_args: '-Wl,-rpath,$ORIGIN/sub',
+    # install_rpath: f'@origin@/sub',
+    link_args: f'-Wl,-rpath,@origin@/sub',
 )
 
 lib_dep = declare_dependency(

--- a/tests/packages/sharedlib-in-package/src/meson.build
+++ b/tests/packages/sharedlib-in-package/src/meson.build
@@ -30,7 +30,11 @@ lib = shared_library(
     c_args: export_dll_args,
     install: true,
     install_dir: py.get_install_dir() / 'mypkg',
-    install_rpath: '$ORIGIN/sub',
+    # install_rpath is not exposed in the Meson introspection data in Meson
+    # versions prior to 1.6.0 and thus cannot be set by meson-python when
+    # building the Python wheel. Use link_args to set the RPATH.
+    # install_rpath: '$ORIGIN/sub',
+    link_args: '-Wl,-rpath,$ORIGIN/sub',
 )
 
 lib_dep = declare_dependency(

--- a/tests/packages/sharedlib-in-package/src/sublib.c
+++ b/tests/packages/sharedlib-in-package/src/sublib.c
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "mypkg_dll.h"
+#include "sublib.h"
 
-MYPKG_DLL int prod(int a, int b) {
+int prod(int a, int b) {
     return a * b;
 }

--- a/tests/packages/sharedlib-in-package/src/sublib.h
+++ b/tests/packages/sharedlib-in-package/src/sublib.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2022 The meson-python developers
+//
+// SPDX-License-Identifier: MIT
+
+#if defined(MYPKG_DLL_EXPORTS)
+    #define EXPORT __declspec(dllexport)
+#elif defined(MYPKG_DLL_IMPORTS)
+    #define EXPORT __declspec(dllimport)
+#else
+    #define EXPORT
+#endif
+
+EXPORT int prod(int a, int b);

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -192,7 +192,7 @@ def test_link_library_in_subproject(venv, wheel_link_library_in_subproject):
 
 
 @pytest.mark.skipif(sys.platform in {'win32', 'cygwin'}, reason='requires RPATH support')
-def test_rpath(wheel_link_against_local_lib, tmp_path):
+def test_link_against_local_lib_rpath(wheel_link_against_local_lib, tmp_path):
     artifact = wheel.wheelfile.WheelFile(wheel_link_against_local_lib)
     artifact.extractall(tmp_path)
 
@@ -200,9 +200,7 @@ def test_rpath(wheel_link_against_local_lib, tmp_path):
     expected = {f'{origin}/../.link_against_local_lib.mesonpy.libs', 'custom-rpath',}
 
     rpath = set(mesonpy._rpath._get_rpath(tmp_path / 'example' / f'_example{EXT_SUFFIX}'))
-    # Verify that rpath is a superset of the expected one: linking to
-    # the Python runtime may require additional rpath entries.
-    assert rpath >= expected
+    assert rpath == expected
 
 
 @pytest.mark.skipif(sys.platform in {'win32', 'cygwin'}, reason='requires RPATH support')

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -180,13 +180,11 @@ def test_local_lib(venv, wheel_link_against_local_lib):
 
 def test_sharedlib_in_package(venv, wheel_sharedlib_in_package):
     venv.pip('install', wheel_sharedlib_in_package)
-    output = venv.python('-c', 'import mypkg; print(mypkg.example_sum(2, 5))')
-    assert int(output) == 7
-    output = venv.python('-c', 'import mypkg; print(mypkg.example_prod(6, 7))')
-    assert int(output) == 42
+    output = venv.python('-c', 'import mypkg; print(mypkg.prodsum(2, 3, 4))')
+    assert int(output) == 11
 
 
-@pytest.mark.skipif(MESON_VERSION < (1, 3, 0), reason='Meson version too old')
+@pytest.mark.skipif(MESON_VERSION < (1, 3, 0), reason='meson too old')
 def test_link_library_in_subproject(venv, wheel_link_library_in_subproject):
     venv.pip('install', wheel_link_library_in_subproject)
     output = venv.python('-c', 'import foo; print(foo.example_sum(3, 6))')


### PR DESCRIPTION
This reorganizes the test package to a flatter layout that helps visualizing all the parts involved in the test and introduces an asymmetry between the source layout and the installation layout that demonstrates the bugs in the RPATH handling.