### PR TITLE
DOC: add instructions for cibuildwheel to support Windows wheels

### DIFF
--- a/docs/how-to-guides/meson-args.rst
+++ b/docs/how-to-guides/meson-args.rst
@@ -190,6 +190,14 @@ permanently in the project's ``pyproject.toml``:
    [tool.meson-python.args]
    setup = ['--vsenv']
 
+And in case you don't want to set ``--vsenv`` as the default, but do want to
+build Windows wheels with MSVC in CI using cibuildwheel:
+
+.. code-block:: toml
+
+   [tool.cibuildwheel.windows]
+   config-settings = { setup-args = ["--vsenv"] }
+
 To set this option temporarily at build-time:
 
 .. tab-set::


### PR DESCRIPTION
I had trouble with building wheels ("Python executable could not be found") and fixed it by specifying the `vsenv` option for cibuildwheel. A similar flag is used by numpy as well, so this is probably indeed needed.