### PR TITLE
MAINT: do not require the pytest-cov toml extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ changelog = 'https://mesonbuild.com/meson-python/changelog.html'
 test = [
   'build',
   'pytest >= 6.0',
-  'pytest-cov[toml]',
+  'pytest-cov',
   'pytest-mock',
   'cython >= 3.0.3', # required for Python 3.12 support
   'wheel',


### PR DESCRIPTION
AFAICT it never existed.

This avoids a warning when installing the test dependencies.