### PR TITLE
CI: switch to supported macOS VM image on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,6 +84,6 @@ freebsd_task:
 
 macos-arm64_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
   install_script: brew install git ninja python@3.11
   << : *test


### PR DESCRIPTION
Apparently the image previously in use has been retired and the jobs were automatically upgraded to this image. Switch it to avoid possible future breakage.