### PR TITLE
TST: use `PyModExport` hook in one test package for Python >=3.15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
         python:
           - '3.9'
           - '3.14'
+          - '3.15.0-alpha.3'
         meson:
           -
         dependencies:
@@ -111,7 +112,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up target Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -162,7 +163,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up target Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -303,7 +304,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
 

--- a/tests/packages/link-library-in-subproject/foo/_examplemod.c
+++ b/tests/packages/link-library-in-subproject/foo/_examplemod.c
@@ -23,7 +23,23 @@ static PyMethodDef methods[] = {
     {NULL, NULL, 0, NULL},
 };
 
-static struct PyModuleDef module = {
+#if PY_VERSION_HEX >= 0x030F0000
+/* Use `PyModExport_<modname>` hook, new in Python 3.15 (PEP 793) */
+static PyModuleDef_Slot example_slots[] = {
+    {Py_mod_name, "_example"},
+    {Py_mod_methods, methods},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL}
+};
+
+PyMODEXPORT_FUNC
+PyModExport__example(void)
+{
+    return example_slots;
+}
+#else
+/* Use legacy method to create a module dynamically */
+static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_example",
     NULL,
@@ -33,5 +49,17 @@ static struct PyModuleDef module = {
 
 PyMODINIT_FUNC PyInit__example(void)
 {
-    return PyModule_Create(&module);
+    PyObject *module;
+
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return module;
+    }
+
+#if Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
+    return module;
 }
+#endif


### PR DESCRIPTION
Opening as draft to discuss. It looks like PEP 793 usage works without any issues - which is what I wanted to check - I think we can integrate this now since that PEP is accepted. We can also wait until 3.15 is further along and we can add that in one or a couple of CI jobs.

There does seem to be an issue with `test_sdist.py::test_symlinks` on Windows, not immediately sure what's going on there yet.