### PR TITLE
ENH: allow to specify editable-verbose in pyproject.toml

### DIFF
--- a/docs/how-to-guides/editable-installs.rst
+++ b/docs/how-to-guides/editable-installs.rst
@@ -173,9 +173,19 @@ might be often useful to be able to inspect the compilation log.
 Setting the :envvar:`MESONPY_EDITABLE_VERBOSE` environment variable
 will result in the output of the build process to be emitted when a
 package is rebuilt on import.  To enable this verbose mode permanently
-for a package, the :option:`editable-verbose` config setting can be
-set to a non-null value when installing the package:
+for a package, the :option:`tool.meson-python.editable-verbose` option
+can be set in ``pyproject.toml`` or the :option:`editable-verbose`
+config setting can be set to a non-null value when installing the
+package:
 
 .. code-block:: console
 
    $ python -m pip install --no-build-isolation -Ceditable-verbose=true --editable .
+
+.. warning::
+
+   ``ninja`` outputs the compilation log on standard output thus it cannot be
+   separated from expected output from command line tools via output
+   redirection. This may make the output of command line tools that import
+   the package harder to use. Consider this carefully when enabling verbose
+   output in package configuration.

--- a/docs/reference/config-settings.rst
+++ b/docs/reference/config-settings.rst
@@ -44,5 +44,7 @@ them.
 
 .. option:: editable-verbose
 
-   Enable :ref:`verbose mode <how-to-guides-editable-installs-verbose>`
-   when building for an :ref:`editable install <how-to-guides-editable-installs>`.
+   Enable :ref:`verbose mode <how-to-guides-editable-installs-verbose>` when
+   building for an :ref:`editable install <how-to-guides-editable-installs>`.
+   Accepts an optional argument taking the values ``true`` or ``false``. This
+   config setting takes precedence over the project setting with the same name.

--- a/docs/reference/pyproject-settings.rst
+++ b/docs/reference/pyproject-settings.rst
@@ -26,6 +26,13 @@ use them and examples.
    documentation. This option ensures that the package authors are aware of
    this requirement.
 
+.. option:: tool.meson-python.editable-verbose
+
+   A boolean indicating whether :ref:`verbose mode
+   <how-to-guides-editable-installs-verbose>` should be enabled when building
+   an :ref:`editable install <how-to-guides-editable-installs>`. This setting
+   can be overridden via the config option of the same name.
+
 .. option:: tool.meson-python.limited-api
 
    A boolean indicating whether the extension modules contained in the

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -610,6 +610,7 @@ def _validate_pyproject_config(pyproject: Dict[str, Any]) -> Dict[str, Any]:
             'exclude': _strings,
             'include': _strings,
         }),
+        'editable-verbose': _bool,
     })
 
     table = pyproject.get('tool', {}).get('meson-python', {})
@@ -624,8 +625,18 @@ def _validate_config_settings(config_settings: Dict[str, Any]) -> Dict[str, Any]
             raise ConfigError(f'Only one value for "{name}" can be specified')
         return value
 
-    def _bool(value: Any, name: str) -> bool:
-        return True
+    def _empty_or_bool(value: Any, name: str) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            if value == 'false':
+                return False
+            if value == 'true':
+                return True
+            # For backward compatibility, treat a missing value as True.
+            if value == '':
+                return True
+        raise ConfigError(f'Invalid value for "{name}": {value!r}')
 
     def _string_or_strings(value: Any, name: str) -> List[str]:
         return list([value,] if isinstance(value, str) else value)
@@ -633,7 +644,7 @@ def _validate_config_settings(config_settings: Dict[str, Any]) -> Dict[str, Any]
     options = {
         'builddir': _string,
         'build-dir': _string,
-        'editable-verbose': _bool,
+        'editable-verbose': _empty_or_bool,
         'dist-args': _string_or_strings,
         'setup-args': _string_or_strings,
         'compile-args': _string_or_strings,
@@ -674,11 +685,10 @@ class Project():
         source_dir: Path,
         build_dir: Path,
         meson_args: Optional[MesonArgs] = None,
-        editable_verbose: bool = False,
+        editable_verbose: Optional[bool] = None,
     ) -> None:
         self._source_dir = pathlib.Path(source_dir).absolute()
         self._build_dir = pathlib.Path(build_dir).absolute()
-        self._editable_verbose = editable_verbose
         self._meson_native_file = self._build_dir / 'meson-python-native-file.ini'
         self._meson_cross_file = self._build_dir / 'meson-python-cross-file.ini'
         self._meson_args: MesonArgs = collections.defaultdict(list)
@@ -691,6 +701,12 @@ class Project():
         pyproject_config = _validate_pyproject_config(pyproject)
         for key, value in pyproject_config.get('args', {}).items():
             self._meson_args[key].extend(value)
+
+        # editable-verbose setting from build options takes precedence over
+        # setting in pyproject.toml
+        if editable_verbose is None:
+            editable_verbose = bool(pyproject_config.get('editable-verbose'))
+        self._editable_verbose = editable_verbose
 
         # meson arguments from the command line take precedence over
         # arguments from the configuration file thus are added later
@@ -1153,7 +1169,7 @@ def _project(config_settings: Optional[Dict[Any, Any]] = None) -> Iterator[Proje
     meson_args = typing.cast('MesonArgs', {name: settings.get(f'{name}-args', []) for name in _MESON_ARGS_KEYS})
     source_dir = os.path.curdir
     build_dir = settings.get('build-dir')
-    editable_verbose = bool(settings.get('editable-verbose'))
+    editable_verbose = settings.get('editable-verbose')
 
     with contextlib.ExitStack() as ctx:
         if build_dir is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,7 +200,7 @@ def meson_fatal_warnings():
     mpatch = pytest.MonkeyPatch()
     mesonpy_project_init = mesonpy.Project.__init__
 
-    def __init__(self, source_dir, build_dir, meson_args=None, editable_verbose=False):
+    def __init__(self, source_dir, build_dir, meson_args=None, editable_verbose=None):
         if pathlib.Path(source_dir).absolute().name not in {
 
                 # The CMake subproject emits ``WARNING: CMake Toolchain:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -23,6 +23,8 @@ import pytest
 
 import mesonpy
 
+from mesonpy._util import chdir
+
 from .conftest import MESON_VERSION, in_git_repo_context, metadata, package_dir
 
 
@@ -457,3 +459,55 @@ def test_ios_project(package_simple, monkeypatch, multiarch, tmp_path):
     assert "\nsystem = 'ios'\n" in cross_config
     assert f"\nc = '{arch}-apple-{subsystem}-clang'\n" in cross_config
     assert f"\nsubsystem = '{subsystem}'\n" in cross_config
+
+
+@pytest.mark.parametrize('verbose', ['true', 'false'])
+def test_editable_verbose_pyproject(tmp_path, verbose):
+    tmp_path.joinpath('pyproject.toml').write_text(textwrap.dedent(f'''
+        [build-system]
+        build-backend = 'mesonpy'
+        requires = ['meson-python']
+
+        [project]
+        name = 'test'
+        version = '1.0.0'
+
+        [tool.meson-python]
+        editable-verbose = {verbose}
+    '''), encoding='utf8')
+
+    tmp_path.joinpath('meson.build').write_text(textwrap.dedent('''
+        project('test')
+    '''), encoding='utf8')
+
+    project = mesonpy.Project(tmp_path, tmp_path / 'build')
+    assert project._editable_verbose == (verbose == 'true')
+
+
+@pytest.mark.parametrize('settings,expected', [
+    ({}, True),
+    ({'editable-verbose': ''}, True),
+    ({'editable-verbose': 'true'}, True),
+    ({'editable-verbose': 'false'}, False),
+], ids=['', '-Ceditable-verbose', '-Ceditable-verbose=true', '-Ceditable-verbose=false'])
+def test_editable_verbose_settings(tmp_path, settings, expected):
+    tmp_path.joinpath('pyproject.toml').write_text(textwrap.dedent('''
+        [build-system]
+        build-backend = 'mesonpy'
+        requires = ['meson-python']
+
+        [project]
+        name = 'test'
+        version = '1.0.0'
+
+        [tool.meson-python]
+        editable-verbose = true
+    '''), encoding='utf8')
+
+    tmp_path.joinpath('meson.build').write_text(textwrap.dedent('''
+        project('test')
+    '''), encoding='utf8')
+
+    with chdir(tmp_path):
+        with mesonpy._project(settings) as project:
+            assert project._editable_verbose == expected


### PR DESCRIPTION
Build config settings passed via the build front-end take precedence over the value configured via the `tool.meson-python.editable-verbose` setting in `pyproject.toml`.

For this to work, the `editable-verbose` config setting is extended to take an optional boolean argument: "true" or "1" are true values, "false" or "0" are false, anything else is invalid. For backward compatibility, the empty string (no argument passed to the config setting) is treated as true.

Addresses a part of gh-820