### PR TITLE
Prepare release 0.20.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,14 @@
 Changelog
 +++++++++
 
+0.20.0
+======
+
+- Add support for targeting the Android platform.
+
+Daniele Nicolodi, Malcolm Smith, Ralf Gommers --- 10-06-2026.
+
+
 0.19.0
 ======
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -84,7 +84,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     MesonArgs = Mapping[MesonArgsKeys, List[str]]
 
 
-__version__ = '0.20.0'
+__version__ = '0.21.0.dev0'
 
 
 _PYPROJECT_METADATA_VERSION = tuple(map(int, pyproject_metadata.__version__.split('.')[:2]))

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -84,7 +84,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     MesonArgs = Mapping[MesonArgsKeys, List[str]]
 
 
-__version__ = '0.20.0.dev0'
+__version__ = '0.20.0'
 
 
 _PYPROJECT_METADATA_VERSION = tuple(map(int, pyproject_metadata.__version__.split('.')[:2]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires = [
 
 [project]
 name = 'meson-python'
-version = '0.20.0.dev0'
+version = '0.20.0'
 description = 'Meson Python build backend (PEP 517)'
 readme = 'README.rst'
 requires-python = '>= 3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires = [
 
 [project]
 name = 'meson-python'
-version = '0.20.0'
+version = '0.21.0.dev0'
 description = 'Meson Python build backend (PEP 517)'
 readme = 'README.rst'
 requires-python = '>= 3.9'


### PR DESCRIPTION
As discussed in https://github.com/mesonbuild/meson-python/pull/824#issuecomment-4629831061. I set the release date to tomorrow; this PR is trivial, but it's the end of the day so I'll finish it off tomorrow, leaving some space for sanity checking this.