### PR TITLE
Test Python 3.15

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,15 +26,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
       - run: python -m pip install --group docs
       - run: python -m sphinx -W docs/ build/docs/
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: build/docs/
 
@@ -48,4 +48,4 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
       - run: python -m pip install build
       - run: python -m build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           path: dist/*
 
@@ -37,7 +37,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
         python:
           - '3.9'
           - '3.14'
+          - '3.15'
         meson:
           -
         dependencies:
@@ -114,6 +115,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
 
       - name: Install Ninja
         run: sudo apt-get install ninja-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,10 +108,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up target Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -142,7 +142,7 @@ jobs:
         run: python -m pytest --showlocals -vv --cov --cov-report=xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         if: ${{ always() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -159,10 +159,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up target Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -196,10 +196,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Cygwin
-        uses: cygwin/cygwin-install-action@v2
+        uses: cygwin/cygwin-install-action@v6
         with:
           packages: >-
             python39
@@ -231,7 +231,7 @@ jobs:
         # Cygwin Python cannot use binary wheels from PyPI. Building
         # some dependencies takes considerable time. Caching the built
         # wheels speeds up the CI job quite a bit.
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache-path.outputs.path }}
           key: cygwin-pip-${{ github.sha }}
@@ -272,7 +272,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Homebrew Python
         run: |
@@ -300,10 +300,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
 

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -1038,7 +1038,15 @@ class Project():
                 # in all cases.
                 while member.issym():
                     name = member.name
-                    target = posixpath.normpath(posixpath.join(posixpath.dirname(member.name), member.linkname))
+                    # Normalize the link target to use forward slashes.  On
+                    # Windows on Python 3.15 rewrites slashes to backslashes in
+                    # symbolic link targets when extracting tar archives (see
+                    # CPython gh-57911), and Meson propagates these backslashed
+                    # targets into the dist tarball. Without this normalization
+                    # the ``posixpath`` resolution below would fail to match the
+                    # link target, dropping links that point inside the archive.
+                    linkname = member.linkname.replace('\\', '/')
+                    target = posixpath.normpath(posixpath.join(posixpath.dirname(member.name), linkname))
                     try:
                         # This can be implemented using the .replace() method
                         # in Python 3.12 and later. The .replace() method was


### PR DESCRIPTION
Python 3.15 is now in beta, so it's time to start testing:

> We ***strongly encourage*** maintainers of third-party Python projects to ***test with 3.15*** during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature-complete entering the beta phase, it is possible that features may be modified or, in rare cases, removed up until the start of the release candidate phase (2026-08-04). Our goal is to have ***no ABI changes*** after beta 4 and as few code changes as possible after the first release candidate. To achieve that, it will be ***extremely important*** to get as much exposure for 3.15 as possible during the beta phase.

https://discuss.python.org/t/python-3-15-0-beta-2-is-here/107610

This is especially important for foundational projects such as meson-python, so libraries know they can use it for their own 3.15 testing. 

---

Also bump GitHub Actions.