### PR TITLE
MAINT: synchronize meson version requirements

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -92,7 +92,9 @@ _PYPROJECT_METADATA_VERSION = tuple(map(int, pyproject_metadata.__version__.spli
 _SUPPORTED_DYNAMIC_FIELDS = {'version', } if _PYPROJECT_METADATA_VERSION < (0, 9) else {'version', 'license', 'license-files'}
 
 _NINJA_REQUIRED_VERSION = '1.8.2'
-_MESON_REQUIRED_VERSION = '0.63.3' # keep in sync with the version requirement in pyproject.toml
+
+# Keep in sync with the version requirement in pyproject.toml
+_MESON_REQUIRED_VERSION = '0.64.0' if sys.version_info < (3, 12) else '1.2.3'
 
 _MESON_ARGS_KEYS = ['dist', 'setup', 'compile', 'install']
 

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -5,6 +5,8 @@
 import pathlib
 import sys
 
+from packaging import requirements, specifiers
+
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -30,3 +32,13 @@ def test_pyproject_dependencies():
     # verify that all build dependencies are project dependencies
     assert not set(build_dependencies) - set(project_dependencies), \
         'pyproject.toml is inconsistent: not all "build-system.requires" are in "project.dependencies"'
+
+
+def test_meson_version_requirement():
+    pyproject = pathlib.Path(__file__).parent.parent.joinpath('pyproject.toml')
+    with open(pyproject, 'rb') as f:
+        data = tomllib.load(f)
+    for dep in data['project']['dependencies']:
+        req = requirements.Requirement(dep)
+        if req.name == 'meson' and req.marker.evaluate():
+            assert req.specifier == specifiers.SpecifierSet(f'>= {mesonpy._MESON_REQUIRED_VERSION}')


### PR DESCRIPTION
Make the runtime version check the same as the dependency declaration in pyproject.toml and add a test to verify the equivalence.

Requiring 0.64 over 0.63.3 was mostly a cosmetic change to allow to write `import('python').find_installation(pure: false)` in the test packages, thus the runtime version check was not update in sync to allow to use the older meson for a while longer in special settings. The old meson version should have been retired by now, and keeping the version checks consistent is less confusing.

xref gh-861