### PR TITLE
MAINT: remove dead code

### DIFF
--- a/mesonpy/_tags.py
+++ b/mesonpy/_tags.py
@@ -9,11 +9,6 @@ import platform
 import struct
 import sys
 import sysconfig
-import typing
-
-
-if typing.TYPE_CHECKING:  # pragma: no cover
-    from typing import Optional
 
 
 # https://peps.python.org/pep-0425/#python-tag
@@ -168,7 +163,7 @@ def get_platform_tag() -> str:
 
 
 class Tag:
-    def __init__(self, interpreter: Optional[str] = None, abi: Optional[str] = None, platform: Optional[str] = None):
+    def __init__(self, interpreter: str | None = None, abi: str | None = None, platform: str | None = None):
         self.interpreter = interpreter or get_interpreter_tag()
         self.abi = abi or get_abi_tag()
         self.platform = platform or get_platform_tag()

--- a/mesonpy/_tags.py
+++ b/mesonpy/_tags.py
@@ -13,7 +13,7 @@ import typing
 
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from typing import Optional, Union
+    from typing import Optional
 
 
 # https://peps.python.org/pep-0425/#python-tag
@@ -34,13 +34,6 @@ def get_interpreter_tag() -> str:
     name = INTERPRETERS.get(name, name)
     version = sys.version_info
     return f'{name}{version[0]}{version[1]}'
-
-
-def _get_config_var(name: str, default: Union[str, int, None] = None) -> Union[str, int, None]:
-    value: Union[str, int, None] = sysconfig.get_config_var(name)
-    if value is None:
-        return default
-    return value
 
 
 def get_abi_tag() -> str:


### PR DESCRIPTION
Left over from Python < 3.9 support removal.