### PR TITLE
BUG: avoid StopIteration for empty split package

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -159,11 +159,15 @@ def _map_to_wheel(
                 other = packages.setdefault(package, path)
                 if other != path:
                     this = os.fspath(pathlib.Path(path, *destination.parts[1:]))
-                    module = next(entry.dst for entry in wheel_files[other] if entry.dst.parts[0] == destination.parts[1])
-                    that = os.fspath(other / module)
+                    module = next((entry.dst for entry in wheel_files[other]
+                                   if entry.dst.parts[0] == destination.parts[1]), None)
+                    locations = f'{this!r}'
+                    if module is not None:
+                        that = os.fspath(other / module)
+                        locations += f' and {that!r}'
                     raise BuildError(
                         f'The {package} package is split between {path} and {other}: '
-                        f'{this!r} and {that!r}, a "pure: false" argument may be missing in meson.build. '
+                        f'{locations}, a "pure: false" argument may be missing in meson.build. '
                         f'It is recommended to set it in "import(\'python\').find_installation()"')
 
             if key == 'install_subdirs' or key == 'targets' and os.path.isdir(src):

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -270,6 +270,29 @@ def test_purelib_platlib_split(package_purelib_platlib_split, tmp_path):
             project.wheel(tmp_path)
 
 
+def test_purelib_platlib_split_empty(tmp_path):
+    # An empty install_subdirs entry registers the package without adding a wheel file.
+    empty = tmp_path / 'empty'
+    empty.mkdir()
+    plat = tmp_path / 'plat.py'
+    plat.touch()
+    sources = {
+        'install_subdirs': {
+            os.fspath(empty): {'destination': os.path.join('{py_purelib}', 'split')},
+        },
+        'targets': {
+            os.fspath(plat): {'destination': os.path.join('{py_platlib}', 'split', 'plat.py')},
+        },
+    }
+
+    with pytest.raises(mesonpy.BuildError, match='The split package is split') as exc_info:
+        mesonpy._map_to_wheel(sources, [], [])
+
+    message = str(exc_info.value)
+    assert repr(os.path.join('platlib', 'split', 'plat.py')) in message
+    assert 'a "pure: false" argument may be missing' in message
+
+
 @pytest.mark.skipif(sys.platform != 'darwin', reason='macOS specific test')
 @pytest.mark.parametrize('arch', ['x86_64', 'arm64'])
 def test_archflags_envvar(package_purelib_and_platlib, monkeypatch, tmp_path, arch):


### PR DESCRIPTION
Fixes #869.

An `install_subdirs` entry can register a top-level package even when its
directory contributes no files to the wheel manifest. If the same package is
then encountered in the other purelib/platlib location, looking up an example
from the first side raised `StopIteration` before the intended split-package
`BuildError` could be reported.

This uses an optional lookup and preserves the existing two-location message
when an example file is available. When the first side is empty, the error
reports the current location together with the existing `pure: false`
guidance.

Validation:

- `python -m pytest -p no:cacheprovider tests/test_wheel.py::test_purelib_platlib_split_empty -q`
- `python -m ruff check mesonpy/__init__.py tests/test_wheel.py`
- a minimal Meson project with two `install_subdir()` calls now reports the
  split-package error without a Python traceback
- `git diff --check`
