### PR TITLE
BUG: assign altsep normalization in the editable path hook

### DIFF
--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -349,7 +349,7 @@ class MesonpyMetaFinder(importlib.abc.MetaPathFinder):
 
     def _path_hook(self, path: str) -> MesonpyPathFinder:
         if os.altsep:
-            path.replace(os.altsep, os.sep)
+            path = path.replace(os.altsep, os.sep)
         path, _, key = path.rpartition(os.sep)
         if path == __file__:
             tree = self._rebuild()

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -349,3 +349,34 @@ def test_editable_rebuild_error(package_purelib_and_platlib, tmp_path, verbose):
 def test_install_data(venv, editable_install_data, tmp_path):
     venv.pip('install', os.fspath(editable_install_data))
     venv.python('-c', 'import package')
+
+
+def test_path_hook_assigns_altsep_normalization(monkeypatch):
+    """The Windows path hook must assign the result of str.replace.
+
+    Import machinery can pass paths that use os.altsep. Without assigning
+    the replace, rpartition(os.sep) does not split the path and the hook
+    never matches __file__.
+    """
+    monkeypatch.setattr(os, 'sep', '\\')
+    monkeypatch.setattr(os, 'altsep', '/')
+
+    win_file = _editable.__file__.replace('/', '\\')
+    monkeypatch.setattr(_editable, '__file__', win_file)
+
+    finder = _editable.MesonpyMetaFinder('pkg', {'pkg'}, '/build', ['true'])
+    rebuilt = []
+
+    def fake_rebuild():
+        rebuilt.append(True)
+        tree = _editable.Node()
+        tree[('subpkg',)] = _editable.Node()
+        return tree
+
+    finder._rebuild = fake_rebuild  # type: ignore[method-assign]
+
+    hook_path = win_file.replace('\\', '/') + '/subpkg'
+    result = finder._path_hook(hook_path)
+    assert rebuilt
+    assert isinstance(result, _editable.MesonpyPathFinder)
+

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -351,32 +351,43 @@ def test_install_data(venv, editable_install_data, tmp_path):
     venv.python('-c', 'import package')
 
 
-def test_path_hook_assigns_altsep_normalization(monkeypatch):
-    """The Windows path hook must assign the result of str.replace.
+@pytest.mark.skipif(not os.altsep, reason='os.altsep is only set on Windows')
+@pytest.mark.skipif(FREE_THREADED_BUILD and CYTHON_VERSION < (3, 1, 0),
+                    reason='Cython version too old, no free-threaded CPython support')
+def test_path_hook_altsep_search_path(package_complex, tmp_path):
+    """The path hook must match submodule search paths that use os.altsep.
 
-    Import machinery can pass paths that use os.altsep. Without assigning
-    the replace, rpartition(os.sep) does not split the path and the hook
-    never matches __file__.
+    After a real editable build, importlib/pkgutil look up subpackages via
+    path hooks. On Windows those paths may use '/' (PYTHONPATH, pathlib,
+    Meson) even though __file__ uses '\\'. The hook normalizes altsep
+    before rpartition(os.sep); discarding the replace means the hook
+    never matches __file__ and subpackage discovery fails.
     """
-    monkeypatch.setattr(os, 'sep', '\\')
-    monkeypatch.setattr(os, 'altsep', '/')
+    if os.altsep in _editable.__file__:
+        pytest.skip('__file__ already uses altsep; hook compares to it as-is')
 
-    win_file = _editable.__file__.replace('/', '\\')
-    monkeypatch.setattr(_editable, '__file__', win_file)
+    project = mesonpy.Project(package_complex, tmp_path)
+    finder = _editable.MesonpyMetaFinder(
+        'complex', {'complex'}, os.fspath(tmp_path), project._build_command, True
+    )
 
-    finder = _editable.MesonpyMetaFinder('pkg', {'pkg'}, '/build', ['true'])
-    rebuilt = []
+    try:
+        sys.meta_path.insert(0, finder)
+        sys.path_hooks.insert(0, finder._path_hook)
 
-    def fake_rebuild():
-        rebuilt.append(True)
-        tree = _editable.Node()
-        tree[('subpkg',)] = _editable.Node()
-        return tree
+        import complex
+        assert complex.__name__ == 'complex'
 
-    finder._rebuild = fake_rebuild  # type: ignore[method-assign]
+        # Same location importlib would use, but spelled with os.altsep.
+        altsep_path = _editable.__file__.replace(os.sep, os.altsep) + os.altsep + 'complex'
+        importer = pkgutil.get_importer(altsep_path)
+        assert isinstance(importer, _editable.MesonpyPathFinder)
 
-    hook_path = win_file.replace('\\', '/') + '/subpkg'
-    result = finder._path_hook(hook_path)
-    assert rebuilt
-    assert isinstance(result, _editable.MesonpyPathFinder)
-
+        names = {module.name for module in pkgutil.iter_modules([altsep_path])}
+        assert 'more' in names
+    finally:
+        del sys.meta_path[0]
+        del sys.path_hooks[0]
+        for name in list(sys.modules):
+            if name == 'complex' or name.startswith('complex.'):
+                del sys.modules[name]


### PR DESCRIPTION
## Summary

`MesonpyMetaFinder._path_hook` intended to normalize Windows path separators before `rpartition(os.sep)`:

```python
if os.altsep:
    path.replace(os.altsep, os.sep)
```

`str.replace` returns a new string and does not mutate in place, so the result was discarded. On Windows, import machinery can pass paths that use `/` (`os.altsep`). Those paths were never split, the hook never matched `__file__`, and the editable finder did not run.

Assign the replace result. Add a unit test that simulates Windows separators on any platform.

Fixes #868.

## Test plan

- [x] Confirmed the discarded `replace` on current `main` (`mesonpy/_editable.py`).
- [x] Isolated reproduction: with `os.sep='\\'` and `os.altsep='/'`, an altsep path does not match `__file__` before the assignment and does match after it.
- [ ] `pytest tests/test_editable.py::test_path_hook_assigns_altsep_normalization`