### PR TITLE
ENH: implement editable loader with PEP 829 .start files

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -553,18 +553,28 @@ class _EditableWheelBuilder(_WheelBuilder):
             whl.writestr(
                 f'{loader_module_name}.py',
                 importlib.resources.files('mesonpy').joinpath('_editable.py').read_bytes() + textwrap.dedent(f'''
-                   install(
-                       {self._metadata.name!r},
-                       {self._top_level_modules!r},
-                       {os.fspath(build_dir)!r},
-                       {build_command!r},
-                       {verbose!r},
-                   )''').encode('utf-8'))
+                   def init():
+                       finder = MesonpyMetaFinder(
+                           {self._metadata.name!r},
+                           {self._top_level_modules!r},
+                           {os.fspath(build_dir)!r},
+                           {build_command!r},
+                           {verbose!r},
+                       )
+                       sys.meta_path.insert(0, finder)
+                       sys.path_hooks.insert(0, finder._path_hook)
+                   ''').encode('utf-8'))
 
-            # install .pth file
-            whl.writestr(
-                f'{self._metadata.canonical_name}-editable.pth',
-                f'import {loader_module_name}'.encode('utf-8'))
+            if sys.version_info >= (3, 15):
+                # install .start file
+                whl.writestr(
+                    f'{self._metadata.canonical_name}-editable.start',
+                    f'{loader_module_name}:init'.encode('utf-8'))
+            else:
+                # install .pth file
+                whl.writestr(
+                    f'{self._metadata.canonical_name}-editable.pth',
+                    f'import {loader_module_name}; {loader_module_name}.init()'.encode('utf-8'))
 
         return wheel_file
 

--- a/mesonpy/_editable.py
+++ b/mesonpy/_editable.py
@@ -410,9 +410,3 @@ class MesonpyPathFinder(importlib.abc.PathEntryFinder):
             elif modname and '.' not in modname:
                 yielded.add(modname)
                 yield prefix + modname, False
-
-
-def install(package: str, names: Set[str], path: str, cmd: List[str], verbose: bool) -> None:
-    finder = MesonpyMetaFinder(package, names, path, cmd, verbose)
-    sys.meta_path.insert(0, finder)
-    sys.path_hooks.insert(0, finder._path_hook)

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -13,6 +13,7 @@ import sys
 from contextlib import redirect_stdout
 
 import pytest
+import wheel.wheelfile
 
 import mesonpy
 
@@ -188,6 +189,21 @@ def test_importlib_resources(tmp_path):
 def test_editable_install(venv, editable_simple):
     venv.pip('install', os.fspath(editable_simple))
     assert venv.python('-c', 'import simple; print(simple.data())').strip() == 'ABC'
+
+
+def test_editable_contents(editable_simple):
+    artifact = wheel.wheelfile.WheelFile(editable_simple)
+
+    impl = 'start' if sys.version_info >= (3, 15) else 'pth'
+    expecting = {
+        'simple-1.0.0.dist-info/METADATA',
+        'simple-1.0.0.dist-info/RECORD',
+        'simple-1.0.0.dist-info/WHEEL',
+        '_simple_editable_loader.py',
+        f'simple-editable.{impl}',
+    }
+
+    assert set(artifact.namelist()) == expecting
 
 
 def test_editble_reentrant(venv, editable_imports_itself_during_build):


### PR DESCRIPTION
on Python 3.15 and later. Editable wheels are Python version specific, thus there is no need to write both a .pth and a .start file for Python versions that support the latter.

Editable wheels implemented with .pth files just imported the implementation module and relied on the execution of the module body on import for the installation of the module loader.  PEP 829 .start files need to specify a callable that takes no arguments. To keep the difference between .pth and .start file implementations to a minimum, define such callable in the implementation module and switch the .pth file to explicitly call it.

Fixes #846