### PR TITLE
MAINT: ignore the wraplock files from meson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/_build
 .cache/
 dist/
 .coverage
+tests/packages/**/.wraplock


### PR DESCRIPTION
This files have started showing up from meson. I think we should ignore them.
